### PR TITLE
PIP Service

### DIFF
--- a/from_scratch.sh
+++ b/from_scratch.sh
@@ -24,6 +24,9 @@ kubectl ${CMD} -f elasticsearch-replicationcontroller.yaml
 # api
 kubectl ${CMD} -f pelias-api.yaml
 
+# pip service
+kubectl ${CMD} -f pelias-pip-service.yaml
+
 # set up schema (just runs a job)
 kubectl ${CMD} -f schema-create-job.yaml
 

--- a/pelias-json-configmap.yaml
+++ b/pelias-json-configmap.yaml
@@ -11,6 +11,13 @@ data:
           "host": "elasticsearch-service"
         }]
       },
+      "api": {
+        "services": {
+          "pip": {
+            "url": "http://pip-service:3102/"
+          }
+        }
+      },
       "acceptance-tests": {
         "endpoints": {
           "local": "http://pelias-api:3100/v1/"

--- a/pelias-json-configmap.yaml
+++ b/pelias-json-configmap.yaml
@@ -47,8 +47,6 @@ data:
         },
         "whosonfirst": {
           "importVenues": false,
-          "importPlace": "404476573",
-          "api_key": "mapzen-NvJYGeT",
           "datapath": "/data/wof/"
         }
       }

--- a/pelias-json-configmap.yaml
+++ b/pelias-json-configmap.yaml
@@ -14,13 +14,13 @@ data:
       "api": {
         "services": {
           "pip": {
-            "url": "http://pip-service:3102/"
+            "url": "http://pelias-pip-service:3102/"
           }
         }
       },
       "acceptance-tests": {
         "endpoints": {
-          "local": "http://pelias-api:3100/v1/"
+          "local": "http://pelias-api-service:3100/v1/"
         }
       },
       "schema": {

--- a/pelias-json-configmap.yaml
+++ b/pelias-json-configmap.yaml
@@ -54,7 +54,7 @@ data:
         },
         "whosonfirst": {
           "importVenues": false,
-          "datapath": "/data/wof/"
+          "datapath": "/data/whosonfirst/"
         }
       }
     }

--- a/pelias-pip-service.yaml
+++ b/pelias-pip-service.yaml
@@ -34,9 +34,9 @@ spec:
               value: "/etc/config/pelias.json"
           resources:
             limits:
-              memory: 4Gi
+              memory: 6Gi
             requests:
-              memory: 3Gi
+              memory: 4Gi
       volumes:
         - name: config-volume
           configMap:

--- a/pelias-pip-service.yaml
+++ b/pelias-pip-service.yaml
@@ -9,6 +9,18 @@ spec:
       labels:
         app: pelias-pip
     spec:
+      initContainers:
+        - name: wof-download
+          image: pelias/whosonfirst
+          command: ["npm", "run", "download"]
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/config
+            - name: data-volume
+              mountPath: /data
+          env:
+            - name: PELIAS_CONFIG
+              value: "/etc/config/pelias.json"
       containers:
         - name: pelias-pip
           image: pelias/pip

--- a/pelias-pip-service.yaml
+++ b/pelias-pip-service.yaml
@@ -1,0 +1,44 @@
+pipVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: pelias-pip
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: pelias-pip
+    spec:
+      containers:
+        - name: pelias-pip
+          image: pelias/pip
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/config
+          env:
+            - name: PELIAS_CONFIG
+              value: "/etc/config/pelias.json"
+          resources:
+            limits:
+              memory: 4Gi
+            requests:
+              memory: 3Gi
+      volumes:
+        - name: config-volume
+          configMap:
+            name: pelias-json-configmap
+            items:
+              - key: pelias.json
+                path: pelias.json
+---
+pipVersion: v1
+kind: Service
+metadata:
+    name: pelias-pip-service
+spec:
+    selector:
+        app: pelias-pip
+    ports:
+        - protocol: TCP
+          port: 3102
+    type: LoadBalancer

--- a/pelias-pip-service.yaml
+++ b/pelias-pip-service.yaml
@@ -37,6 +37,11 @@ spec:
               memory: 8Gi
             requests:
               memory: 6Gi
+          readinessProbe:
+            httpGet:
+              path: /12/12
+              port: 3102
+            initialDelaySeconds: 60 #PIP service takes a long time to start up
       volumes:
         - name: config-volume
           configMap:

--- a/pelias-pip-service.yaml
+++ b/pelias-pip-service.yaml
@@ -57,4 +57,4 @@ spec:
     ports:
         - protocol: TCP
           port: 3102
-    type: LoadBalancer
+    type: ClusterIP

--- a/pelias-pip-service.yaml
+++ b/pelias-pip-service.yaml
@@ -1,4 +1,4 @@
-pipVersion: extensions/v1beta1
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: pelias-pip

--- a/pelias-pip-service.yaml
+++ b/pelias-pip-service.yaml
@@ -27,6 +27,8 @@ spec:
           volumeMounts:
             - name: config-volume
               mountPath: /etc/config
+            - name: data-volume
+              mountPath: /data
           env:
             - name: PELIAS_CONFIG
               value: "/etc/config/pelias.json"
@@ -42,6 +44,8 @@ spec:
             items:
               - key: pelias.json
                 path: pelias.json
+        - name: data-volume
+          emptyDir: {}
 ---
 pipVersion: v1
 kind: Service

--- a/pelias-pip-service.yaml
+++ b/pelias-pip-service.yaml
@@ -34,9 +34,9 @@ spec:
               value: "/etc/config/pelias.json"
           resources:
             limits:
-              memory: 6Gi
+              memory: 8Gi
             requests:
-              memory: 4Gi
+              memory: 6Gi
       volumes:
         - name: config-volume
           configMap:


### PR DESCRIPTION
This sets up the PIP service for use in Kubernetes. The PIP service is a pretty heavy thing: it requires 6GB of memory minimum, and takes quite a while to start up. During development one of the underlying EBS volumes for one of the cluster nodes ran out of burst performance, so it took almost half an hour for the PIP service to start.

Because it takes so long a [readiness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#define-readiness-probes) is used that ensures the pods are not actually sent traffic until fully loaded.