### PR TITLE
Placeholder Service

### DIFF
--- a/from_scratch.sh
+++ b/from_scratch.sh
@@ -28,7 +28,7 @@ kubectl ${CMD} -f pelias-api.yaml
 kubectl ${CMD} -f pelias-pip-service.yaml
 
 # placeholder
-kubectl ${CMD} -f pelias-placeholder.yaml
+kubectl ${CMD} -f pelias-placeholder-service.yaml
 
 # set up schema (just runs a job)
 kubectl ${CMD} -f schema-create-job.yaml

--- a/from_scratch.sh
+++ b/from_scratch.sh
@@ -27,6 +27,9 @@ kubectl ${CMD} -f pelias-api.yaml
 # pip service
 kubectl ${CMD} -f pelias-pip-service.yaml
 
+# placeholder
+kubectl ${CMD} -f pelias-placeholder.yaml
+
 # set up schema (just runs a job)
 kubectl ${CMD} -f schema-create-job.yaml
 

--- a/pelias-placeholder-service.yaml
+++ b/pelias-placeholder-service.yaml
@@ -13,7 +13,7 @@ spec:
         - name: placeholder-download
           image: busybox
           command: ["sh", "-c",
-            "curl -s http://pelias-data.s3.amazonaws.com/placeholder/graph.json.gz | gunzip > /data/placeholder/graph.json\n
+            "curl -s http://pelias-data.s3.amazonaws.com/placeholder/graph.json.gz | gunzip > /data/placeholder/graph.json &&\n
              curl -s http://pelias-data.s3.amazonaws.com/placeholder/store.sqlite3.gz | gunzip > /data/placeholder/store.sqlite3" ]
           volumeMounts:
             - name: data-volume

--- a/pelias-placeholder-service.yaml
+++ b/pelias-placeholder-service.yaml
@@ -30,9 +30,11 @@ spec:
               value: "/data/placeholder/"
           resources:
             limits:
-              memory: 3Gi
+              memory: 1Gi
+              cpu: 2
             requests:
-              memory: 2Gi
+              memory: 512Mi
+              cpu: 1
       volumes:
         - name: data-volume
           emptyDir: {}

--- a/pelias-placeholder-service.yaml
+++ b/pelias-placeholder-service.yaml
@@ -13,8 +13,8 @@ spec:
         - name: placeholder-download
           image: busybox
           command: ["sh", "-c",
-            "curl -s http://pelias-data.s3.amazonaws.com/placeholder/graph.json.gz | gunzip > /data/placeholder/graph.json &&\n
-             curl -s http://pelias-data.s3.amazonaws.com/placeholder/store.sqlite3.gz | gunzip > /data/placeholder/store.sqlite3" ]
+            "wget -O- http://pelias-data.s3.amazonaws.com/placeholder/graph.json.gz | gunzip > /data/placeholder/graph.json &\n
+             wget -O- http://pelias-data.s3.amazonaws.com/placeholder/store.sqlite3.gz | gunzip > /data/placeholder/store.sqlite3" ]
           volumeMounts:
             - name: data-volume
               mountPath: /data

--- a/pelias-placeholder-service.yaml
+++ b/pelias-placeholder-service.yaml
@@ -13,7 +13,8 @@ spec:
         - name: placeholder-download
           image: busybox
           command: ["sh", "-c",
-            "wget -O- http://pelias-data.s3.amazonaws.com/placeholder/graph.json.gz | gunzip > /data/placeholder/graph.json &\n
+            "mkdir -p /data/placeholder/ &&\n
+             wget -O- http://pelias-data.s3.amazonaws.com/placeholder/graph.json.gz | gunzip > /data/placeholder/graph.json &\n
              wget -O- http://pelias-data.s3.amazonaws.com/placeholder/store.sqlite3.gz | gunzip > /data/placeholder/store.sqlite3" ]
           volumeMounts:
             - name: data-volume

--- a/pelias-placeholder-service.yaml
+++ b/pelias-placeholder-service.yaml
@@ -1,0 +1,49 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: pelias-placeholder
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: pelias-placeholder
+    spec:
+      initContainers:
+        - name: placeholder-download
+          image: busybox
+          command: ["sh", "-c",
+            "curl -s http://pelias-data.s3.amazonaws.com/placeholder/graph.json.gz | gunzip > /data/placeholder/graph.json\n
+             curl -s http://pelias-data.s3.amazonaws.com/placeholder/store.sqlite3.gz | gunzip > /data/placeholder/store.sqlite3" ]
+          volumeMounts:
+            - name: data-volume
+              mountPath: /data
+      containers:
+        - name: pelias-placeholder
+          image: pelias/placeholder
+          volumeMounts:
+            - name: data-volume
+              mountPath: /data
+          env:
+            - name: PLACEHOLDER_DATA
+              value: "/data/placeholder/"
+          resources:
+            limits:
+              memory: 3Gi
+            requests:
+              memory: 2Gi
+      volumes:
+        - name: data-volume
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+    name: pelias-placeholder-service
+spec:
+    selector:
+        app: pelias-placeholder
+    ports:
+        - protocol: TCP
+          port: 3000
+    type: ClusterIP


### PR DESCRIPTION
The placeholder service was really easy to set up. Downloading the data isn't automatic, but it was possible to put together a simple shell script in an `initContainer` to do it.

The service only needs about 500MB of RAM, so it has very low resource limits and will be easy to squeeze multiple pods for redundancy on almost any Kubernetes cluster!