### PR TITLE
Convert Elasticsearch Terraform scripts to a module

### DIFF
--- a/elasticsearch/packer/pelias-elasticsearch.json
+++ b/elasticsearch/packer/pelias-elasticsearch.json
@@ -20,7 +20,7 @@
       "owners": ["099720109477"],
       "most_recent": true
     },
-    "instance_type": "r3.xlarge",
+    "instance_type": "r4.xlarge",
     "ssh_username": "ubuntu",
     "ami_name": "pelias-elasticsearch-{{timestamp}}"
   }],

--- a/elasticsearch/packer/pelias-elasticsearch.json
+++ b/elasticsearch/packer/pelias-elasticsearch.json
@@ -2,13 +2,15 @@
   "variables": {
     "elasticsearch_version": "2.4.6",
     "aws_access_key": "",
-    "aws_secret_key": ""
+    "aws_secret_key": "",
+    "subnet_id": ""
   },
   "builders": [{
     "type": "amazon-ebs",
     "access_key": "{{user `aws_access_key`}}",
     "secret_key": "{{user `aws_secret_key`}}",
     "region": "us-east-1",
+    "subnet_id": "{{user `subnet_id`}}",
     "source_ami_filter": {
       "filters": {
         "virtualization-type": "hvm",

--- a/elasticsearch/packer/pelias-elasticsearch.json
+++ b/elasticsearch/packer/pelias-elasticsearch.json
@@ -1,6 +1,6 @@
 {
   "variables": {
-    "elasticsearch_version": "",
+    "elasticsearch_version": "2.4.6",
     "aws_access_key": "",
     "aws_secret_key": ""
   },

--- a/elasticsearch/terraform/elb.tf
+++ b/elasticsearch/terraform/elb.tf
@@ -1,5 +1,5 @@
 resource "aws_elb" "elasticsearch_elb" {
-  name                      = "${var.service_name}-${var.environment}-elasticsearch-elb"
+  name                      = "${var.service_name}-${var.environment}-es-elb"
   security_groups           = ["${aws_security_group.elasticsearch_elb.id}"]
   subnets                   = ["${data.aws_subnet_ids.all_subnets.ids}"]
   cross_zone_load_balancing = true

--- a/elasticsearch/terraform/iam.tf
+++ b/elasticsearch/terraform/iam.tf
@@ -1,11 +1,11 @@
 resource "aws_iam_role" "elasticsearch" {
   name               = "${var.service_name}-${var.environment}-elasticsearch-discovery-role"
-  assume_role_policy = "${file("policies/role.json")}"
+  assume_role_policy = "${file("${path.module}/policies/role.json")}"
 }
 
 resource "aws_iam_role_policy" "elasticsearch" {
   name   = "${var.service_name}-${var.environment}-elasticsearch-discovery-policy"
-  policy = "${file("policies/policy.json")}"
+  policy = "${file("${path.module}/policies/policy.json")}"
   role   = "${aws_iam_role.elasticsearch.id}"
 }
 

--- a/elasticsearch/terraform/main.tf
+++ b/elasticsearch/terraform/main.tf
@@ -10,6 +10,8 @@ data "template_file" "user_data" {
     es_allowed_urls        = "${var.es_allowed_urls}"
     aws_security_group     = "${aws_security_group.elasticsearch.id}"
     aws_region             = "${var.aws_region}"
+    expected_nodes         = "${var.elasticsearch_desired_instances}"
+    minimum_master_nodes   = "${var.elasticsearch_desired_instances/2 + 1}"
   }
 }
 

--- a/elasticsearch/terraform/main.tf
+++ b/elasticsearch/terraform/main.tf
@@ -1,11 +1,5 @@
-provider "aws" {
-  region     = "${var.aws_region}"
-  access_key = "${var.aws_access_key}"
-  secret_key = "${var.aws_secret_key}"
-}
-
 data "template_file" "user_data" {
-  template = "${file("${path.root}/templates/user-data.tpl")}"
+  template = "${file("${path.module}/templates/user-data.tpl")}"
 
   vars {
     data_volume_name       = "${var.elasticsearch_data_volume_name}"

--- a/elasticsearch/terraform/security_groups.tf
+++ b/elasticsearch/terraform/security_groups.tf
@@ -27,6 +27,7 @@ resource "aws_security_group" "elasticsearch" {
     self      = true
   }
 
+  # all outbound traffic is allowed
   egress {
     from_port   = 0
     to_port     = 0

--- a/elasticsearch/terraform/templates/user-data.tpl
+++ b/elasticsearch/terraform/templates/user-data.tpl
@@ -15,8 +15,9 @@ path.logs: ${elasticsearch_log_dir}
 bootstrap.mlockall: true
 network.host: _ec2:privateIpv4_
 discovery.type: ec2
+discovery.ec2.groups: ${aws_security_group}
+
 cloud.aws.region: ${aws_region}
-cloud.aws.groups: ${aws_security_group}
 repositories.url.allowed_urls: ["${es_allowed_urls}"]
 EOF
 

--- a/elasticsearch/terraform/templates/user-data.tpl
+++ b/elasticsearch/terraform/templates/user-data.tpl
@@ -15,10 +15,14 @@ path.logs: ${elasticsearch_log_dir}
 bootstrap.mlockall: true
 network.host: _ec2:privateIpv4_
 discovery.type: ec2
+discovery.zen.minimum_master_nodes: ${minimum_master_nodes}
 discovery.ec2.groups: ${aws_security_group}
 
 cloud.aws.region: ${aws_region}
 repositories.url.allowed_urls: ["${es_allowed_urls}"]
+
+gateway.recover_after_time: 5m
+gateway.expected_nodes: ${expected_nodes}
 EOF
 
 # heap size

--- a/elasticsearch/terraform/variables.tf
+++ b/elasticsearch/terraform/variables.tf
@@ -4,14 +4,6 @@ variable "ssh_key_name" {
   description = "Name of AWS key pair"
 }
 
-variable "aws_access_key" {
-  description = "The access key for the terraform user"
-}
-
-variable "aws_secret_key" {
-  description = "The secret key for the terraform user"
-}
-
 variable "aws_region" {
   description = "The AWS region to create things in."
   default     = "us-east-1"

--- a/elasticsearch/terraform/vpc.tf
+++ b/elasticsearch/terraform/vpc.tf
@@ -2,4 +2,8 @@
 # this is used when creating ELBs and ASGs
 data "aws_subnet_ids" "all_subnets" {
   vpc_id = "${var.aws_vpc_id}"
+
+  tags {
+	  Name = "NonProd"
+  }
 }


### PR DESCRIPTION
These code changes allow the Terraform scripts embedded in this repo to be used as a module in another terraform setup, rather than only directly. These scripts are used to spin up an Elasticsearch cluster since running Elasticsearch on Kubernetes is not ideal.

Running them as a module is much more flexible and allows anyone to spin up multiple clusters with different settings more easily.