### PR TITLE
Full Planet build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pelias Kubernetes Configuration
 
-Here live Kubernetes configuration files to create a production ready instance of Pelias.
+This repository contains Kubernetes configuration files to create a production ready instance of Pelias.
 
 This configuration is meant to be run on Kubernetes using real hardware or full sized virtual
 machines in the cloud. Technically it could work on a personal computer with
@@ -18,27 +18,27 @@ First, set up a Kubernetes cluster however works best for you. A popular choice 
 ### Sizing the Kubernetes cluster
 
 A working Pelias cluster contains the following services:
-* Pelias API (requires about 3GB of RAM) (**required**)
-* Placeholder Service (Requires 512MB of RAM) (**recommended**)
-* Point in Polygon (PIP) Service (Requires 6GB of RAM) (**recommended if reverse geocoding is
-  important**)
-* Interpolation Service (not implemented yet)
+* Pelias API (requires about 2GB of RAM) (**required**)
+* Placeholder Service (Requires 512MB of RAM) (**strongly recommended**)
+* Point in Polygon (PIP) Service (Requires 6GB of RAM) (**required for reverse geocoding**)
+* Interpolation Service (requires ~2GB of RAM)
 
 Some of the following importers will additionally have to be run to initially populate data
-* Who's on First (requires about 1GB of RAM, not implemented yet)
-* OpenStretMap (requires 6GB of RAM)
+* Who's on First (requires about 1GB of RAM)
+* OpenStretMap (requires ~0.25GB of RAM)
 * OpenAddresses (requires 6GB of RAM)
-* Geonames (requires 6GB of RAM, not implemented yet)
-* Polylines (requires 6GB of RAM, not implemented yet)
+* Geonames (requires ~0.5GB of RAM)
+* Polylines (requires 6GB of RAM for now)
+
+Finally, the importers require the PIP service to be running)
 
 Use the[data sources](https://mapzen.com/documentation/search/data-sources/) documentation to decide
 which importers to be run.
 
 Importers can be run in any order, in parallel or one at a time.
 
-These configuration files have two pods for each service to ensure redundancy. This means around
-20GB of RAM is required to bring up all these services, and up to another 30GB of RAM is needed to
-run all the importers at once. 3 instances with 8GB of RAM each is a good starting point just for
+This means around 10GB of RAM is required to bring up all the services, and up to another 15GB of RAM is needed to
+run all the importers at once. 2 instances with 8GB of RAM each is a good starting point just for
 the services.
 
 If using kops, it defaults to `t2.small` instances, which are far too small (they only have 2GB of ram).
@@ -73,13 +73,3 @@ it can be useful to open a shell inside a running container for debugging:
 # kubectl exec -it {{pod_name}} -- {{command}}
 kubectl exec -it pelias-pip-3625698757-dtzmd -- /bin/bash
 ```
-
-## Using the Dockerfile
-
-A Dockerfile is included that sets up all tools required for this repository. It can be used as a
-helper for creating an environment to run these scripts. It will mount your local copy of the
-pelias/kubernetes repository, your `~/.kube` directory for `kubectl` configuration, and your local
-`~/.aws` directory for AWS configuration.
-
-By running: `docker-compose run kubernetes bash`, you will get a shell that has all tools involved,
-and knows about your configuration.

--- a/build/Chart.yaml
+++ b/build/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
-description: A Helm chart for Kubernetes
-name: build
+description: Run a Pelias build
+name: pelias-build
 version: 0.1.0

--- a/build/templates/geonames-import-job.tpl
+++ b/build/templates/geonames-import-job.tpl
@@ -9,7 +9,7 @@ spec:
     spec:
       initContainers:
         - name: geonames-download
-          image: pelias/geonames:{{ .Values.geonamesDockerTag | default "latests" }}
+          image: pelias/geonames:{{ .Values.geonamesDockerTag | default "latest" }}
           command: ["npm", "run", "download"]
           volumeMounts:
           - name: config-volume
@@ -28,7 +28,7 @@ spec:
               cpu: 1
       containers:
       - name: geonames-import-container
-        image: pelias/geonames:{{ .Values.geonamesDockerTag | default "latests" }}
+        image: pelias/geonames:{{ .Values.geonamesDockerTag | default "latest" }}
         command: ["npm", "start"]
         volumeMounts:
           - name: config-volume

--- a/build/templates/geonames-import-job.tpl
+++ b/build/templates/geonames-import-job.tpl
@@ -1,0 +1,58 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: geonames-import
+spec:
+  template:
+    metadata:
+      name: geonames-import-pod
+    spec:
+      initContainers:
+        - name: geonames-download
+          image: pelias/geonames:{{ .Values.geonamesDockerTag | default "latests" }}
+          command: ["npm", "run", "download"]
+          volumeMounts:
+          - name: config-volume
+            mountPath: /etc/config
+          - name: data-volume
+            mountPath: /data
+          env:
+          - name: PELIAS_CONFIG
+            value: "/etc/config/pelias.json"
+          resources:
+            limits:
+              memory: 512Mi
+              cpu: 1
+            requests:
+              memory: 512Mi
+              cpu: 1
+      containers:
+      - name: geonames-import-container
+        image: pelias/geonames:{{ .Values.geonamesDockerTag | default "latests" }}
+        command: ["npm", "start"]
+        volumeMounts:
+          - name: config-volume
+            mountPath: /etc/config
+          - name: data-volume
+            mountPath: /data
+        env:
+          - name: PELIAS_CONFIG
+            value: "/etc/config/pelias.json"
+        resources:
+          limits:
+            memory: 3Gi
+            cpu: 2
+          requests:
+            memory: 512Mi
+            cpu: 1
+      restartPolicy: OnFailure
+      volumes:
+      - name: config-volume
+        configMap:
+          name: pelias-json-configmap
+          items:
+          - key: pelias.json
+            path: pelias.json
+      - name: data-volume
+        persistentVolumeClaim:
+          claimName: pelias-build-pvc

--- a/build/templates/openaddresses-import-job.tpl
+++ b/build/templates/openaddresses-import-job.tpl
@@ -38,7 +38,7 @@ spec:
           requests:
             memory: 2Gi
             cpu: 1
-      restartPolicy: Never
+      restartPolicy: OnFailure
       volumes:
         - name: config-volume
           configMap:

--- a/build/templates/openaddresses-import-job.tpl
+++ b/build/templates/openaddresses-import-job.tpl
@@ -9,7 +9,7 @@ spec:
     spec:
       initContainers:
       - name: openaddresses-download
-        image: pelias/openaddresses:master
+        image: pelias/openaddresses:{{ .Values.openaddressesDockerTag | default "latest" }}
         command: ["npm", "run", "download"]
         volumeMounts:
           - name: config-volume
@@ -28,7 +28,7 @@ spec:
             cpu: 0.5
       containers:
       - name: openaddresses-import-container
-        image: pelias/openaddresses:master
+        image: pelias/openaddresses:{{ .Values.openaddressesDockerTag | default "latest" }}
         command: ["npm", "start"]
         volumeMounts:
           - name: config-volume

--- a/build/templates/openaddresses-import-job.tpl
+++ b/build/templates/openaddresses-import-job.tpl
@@ -8,17 +8,24 @@ spec:
       name: openaddresses-import-pod
     spec:
       initContainers:
-        - name: openaddresses-download
-          image: pelias/openaddresses:master
-          command: ["npm", "run", "download"]
-          volumeMounts:
-            - name: config-volume
-              mountPath: /etc/config
-            - name: data-volume
-              mountPath: /data
-          env:
-            - name: PELIAS_CONFIG
-              value: "/etc/config/pelias.json"
+      - name: openaddresses-download
+        image: pelias/openaddresses:master
+        command: ["npm", "run", "download"]
+        volumeMounts:
+          - name: config-volume
+            mountPath: /etc/config
+          - name: data-volume
+            mountPath: /data
+        env:
+          - name: PELIAS_CONFIG
+            value: "/etc/config/pelias.json"
+        resources:
+          limits:
+            memory: 1Gi
+            cpu: 1.5
+          requests:
+            memory: 256Mi
+            cpu: 0.5
       containers:
       - name: openaddresses-import-container
         image: pelias/openaddresses:master
@@ -33,10 +40,10 @@ spec:
             value: "/etc/config/pelias.json"
         resources:
           limits:
-            memory: 3Gi
-            cpu: 1.5
-          requests:
             memory: 2Gi
+            cpu: 2
+          requests:
+            memory: 512Mi
             cpu: 1
       restartPolicy: OnFailure
       volumes:

--- a/build/templates/openstreetmap-import-job.tpl
+++ b/build/templates/openstreetmap-import-job.tpl
@@ -38,7 +38,7 @@ spec:
           requests:
             memory: 2Gi
             cpu: 1.5
-      restartPolicy: Never
+      restartPolicy: OnFailure
       volumes:
         - name: config-volume
           configMap:

--- a/build/templates/openstreetmap-import-job.tpl
+++ b/build/templates/openstreetmap-import-job.tpl
@@ -8,17 +8,24 @@ spec:
       name: openstreetmap-import
     spec:
       initContainers:
-        - name: openstreetmap-download
-          image: pelias/openstreetmap:master
-          command: ["npm", "run", "download"]
-          volumeMounts:
-            - name: config-volume
-              mountPath: /etc/config
-            - name: data-volume
-              mountPath: /data
-          env:
-            - name: PELIAS_CONFIG
-              value: "/etc/config/pelias.json"
+      - name: openstreetmap-download
+        image: pelias/openstreetmap:master
+        command: ["npm", "run", "download"]
+        volumeMounts:
+          - name: config-volume
+            mountPath: /etc/config
+          - name: data-volume
+            mountPath: /data
+        env:
+          - name: PELIAS_CONFIG
+            value: "/etc/config/pelias.json"
+        resources:
+          limits:
+            memory: 1Gi
+            cpu: 2
+          requests:
+            memory: 256Mi
+            cpu: 0.5
       containers:
       - name: openstreetmap-import-container
         image: pelias/openstreetmap:master
@@ -33,10 +40,10 @@ spec:
             value: "/etc/config/pelias.json"
         resources:
           limits:
-            memory: 6Gi
-            cpu: 2
+            memory: 8Gi
+            cpu: 3
           requests:
-            memory: 2Gi
+            memory: 4Gi
             cpu: 1.5
       restartPolicy: OnFailure
       volumes:

--- a/build/templates/openstreetmap-import-job.tpl
+++ b/build/templates/openstreetmap-import-job.tpl
@@ -9,7 +9,7 @@ spec:
     spec:
       initContainers:
       - name: openstreetmap-download
-        image: pelias/openstreetmap:master
+        image: pelias/openstreetmap:{{ .Values.openstreetmapDockerTag | default "latest"}}
         command: ["npm", "run", "download"]
         volumeMounts:
           - name: config-volume
@@ -28,7 +28,7 @@ spec:
             cpu: 0.5
       containers:
       - name: openstreetmap-import-container
-        image: pelias/openstreetmap:master
+        image: pelias/openstreetmap:{{ .Values.openstreetmapDockerTag | default "latest"}}
         command: ["npm", "start"]
         volumeMounts:
           - name: config-volume

--- a/build/templates/polylines-import-job.tpl
+++ b/build/templates/polylines-import-job.tpl
@@ -1,0 +1,45 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: polylines-import
+spec:
+  template:
+    metadata:
+      name: polylines-import-pod
+    spec:
+      initContainers:
+        - name: polylines-download
+          image: busybox
+          command: ["sh", "-c"]
+          args: ["mkdir -p /data/polylines && wget -O- https://s3.amazonaws.com/pelias-data/road-network.gz | gunzip > /data/polylines/extract.0sv"]
+          volumeMounts:
+            - name: data-volume
+              mountPath: /data
+      containers:
+      - name: polylines-import-container
+        image: pelias/polylines:latest #{{ .Values.polylinesDockerTag | default "latest" }}
+        command: ["npm", "start"]
+        volumeMounts:
+          - name: config-volume
+            mountPath: /etc/config
+          - name: data-volume
+            mountPath: /data
+        env:
+          - name: PELIAS_CONFIG
+            value: "/etc/config/pelias.json"
+        resources:
+          limits:
+            memory: 8Gi
+          requests:
+            memory: 6Gi
+      restartPolicy: OnFailure
+      volumes:
+        - name: config-volume
+          configMap:
+            name: pelias-json-configmap
+            items:
+              - key: pelias.json
+                path: pelias.json
+        - name: data-volume
+          persistentVolumeClaim:
+            claimName: pelias-build-pvc

--- a/build/templates/polylines-import-job.tpl
+++ b/build/templates/polylines-import-job.tpl
@@ -17,7 +17,7 @@ spec:
               mountPath: /data
       containers:
       - name: polylines-import-container
-        image: pelias/polylines:latest #{{ .Values.polylinesDockerTag | default "latest" }}
+        image: pelias/polylines:{{ .Values.polylinesDockerTag | default "latest" }}
         command: ["npm", "start"]
         volumeMounts:
           - name: config-volume

--- a/build/templates/schema-create-job.tpl
+++ b/build/templates/schema-create-job.tpl
@@ -22,7 +22,7 @@ spec:
             memory: 1Gi
             cpu: 0.1
           requests:
-            memory: 1Gi
+            memory: 256Mi
             cpu: 0.1
       restartPolicy: OnFailure
       volumes:

--- a/build/templates/schema-create-job.tpl
+++ b/build/templates/schema-create-job.tpl
@@ -24,7 +24,7 @@ spec:
           requests:
             memory: 1Gi
             cpu: 0.1
-      restartPolicy: Never
+      restartPolicy: OnFailure
       volumes:
         - name: config-volume
           configMap:

--- a/build/templates/schema-create-job.tpl
+++ b/build/templates/schema-create-job.tpl
@@ -7,6 +7,18 @@ spec:
     metadata:
       name: schema-create
     spec:
+      {{ if .Values.schemaDrop | default false }}
+      initContainers:
+      - name: schema-drop
+        image: pelias/schema
+        command: ["npm", "run", "drop_index", "--", "-f"]
+        volumeMounts:
+          - name: config-volume
+            mountPath: /etc/config
+        env:
+          - name: PELIAS_CONFIG
+            value: "/etc/config/pelias.json"
+      {{ end }}
       containers:
       - name: schema-create
         image: pelias/schema

--- a/build/templates/whosonfirst-import-job.tpl
+++ b/build/templates/whosonfirst-import-job.tpl
@@ -8,20 +8,27 @@ spec:
       name: whosonfirst-import
     spec:
       initContainers:
-        - name: wof-download
-          image: pelias/whosonfirst
-          command: ["npm", "run", "download"]
-          volumeMounts:
-            - name: config-volume
-              mountPath: /etc/config
-            - name: data-volume
-              mountPath: /data
-          env:
-            - name: PELIAS_CONFIG
-              value: "/etc/config/pelias.json"
+      - name: wof-download
+        image: pelias/whosonfirst:master
+        command: ["npm", "run", "download"]
+        volumeMounts:
+          - name: config-volume
+            mountPath: /etc/config
+          - name: data-volume
+            mountPath: /data
+        env:
+          - name: PELIAS_CONFIG
+            value: "/etc/config/pelias.json"
+        resources:
+          limits:
+            memory: 1Gi
+            cpu: 4
+          requests:
+            memory: 512Mi
+            cpu: 1.5
       containers:
       - name: whosonfirst-import-container
-        image: pelias/whosonfirst
+        image: pelias/whosonfirst:master
         command: ["npm", "start"]
         volumeMounts:
           - name: config-volume

--- a/build/templates/whosonfirst-import-job.tpl
+++ b/build/templates/whosonfirst-import-job.tpl
@@ -54,5 +54,4 @@ spec:
               - key: pelias.json
                 path: pelias.json
         - name: data-volume
-          persistentVolumeClaim:
-            claimName: pelias-build-pvc
+          emptyDir: {}

--- a/build/templates/whosonfirst-import-job.tpl
+++ b/build/templates/whosonfirst-import-job.tpl
@@ -38,7 +38,7 @@ spec:
           requests:
             memory: 1Gi
             cpu: 1
-      restartPolicy: Never
+      restartPolicy: OnFailure
       volumes:
         - name: config-volume
           configMap:

--- a/build/templates/whosonfirst-import-job.tpl
+++ b/build/templates/whosonfirst-import-job.tpl
@@ -9,7 +9,7 @@ spec:
     spec:
       initContainers:
       - name: wof-download
-        image: pelias/whosonfirst:master
+        image: pelias/whosonfirst:{{ .Values.whosonfirstDockerTag | default "latest" }}
         command: ["npm", "run", "download"]
         volumeMounts:
           - name: config-volume
@@ -28,7 +28,7 @@ spec:
             cpu: 1.5
       containers:
       - name: whosonfirst-import-container
-        image: pelias/whosonfirst:master
+        image: pelias/whosonfirst:{{ .Values.whosonfirstDockerTag | default "latest" }}
         command: ["npm", "start"]
         volumeMounts:
           - name: config-volume

--- a/elasticsearch/terraform/main.tf
+++ b/elasticsearch/terraform/main.tf
@@ -67,6 +67,12 @@ resource "aws_autoscaling_group" "elasticsearch" {
     propagate_at_launch = true
   }
 
+  tag {
+    key                 = "team"
+    value               = "${var.service_name}"
+    propagate_at_launch = true
+  }
+
   lifecycle {
     create_before_destroy = true
   }

--- a/templates/api-deployment.tpl
+++ b/templates/api-deployment.tpl
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
         - name: pelias-api
-          image: pelias/api:{{ .Values.apiDockerTag | default "production" }}
+          image: pelias/api:{{ .Values.apiDockerTag | default "latest" }}
           volumeMounts:
             - name: config-volume
               mountPath: /etc/config

--- a/templates/api-deployment.tpl
+++ b/templates/api-deployment.tpl
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: pelias-api
 spec:
-  replicas: 1
+  replicas: {{ .Values.apiReplicas | default 1 }}
   template:
     metadata:
       labels:

--- a/templates/api-deployment.tpl
+++ b/templates/api-deployment.tpl
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
         - name: pelias-api
-          image: pelias/api
+          image: pelias/api:{{ .Values.apiDockerTag | default "production" }}
           volumeMounts:
             - name: config-volume
               mountPath: /etc/config

--- a/templates/api-deployment.tpl
+++ b/templates/api-deployment.tpl
@@ -20,9 +20,11 @@ spec:
               value: "/etc/config/pelias.json"
           resources:
             limits:
-              memory: 4Gi
-            requests:
               memory: 3Gi
+              cpu: 1.5
+            requests:
+              memory: 2Gi
+              cpu: 0.5
       volumes:
         - name: config-volume
           configMap:

--- a/templates/configmap.tpl
+++ b/templates/configmap.tpl
@@ -44,19 +44,19 @@ data:
         },
         "geonames": {
           "datapath": "/data/geonames",
-          "countryCode": "us"
+          "countryCode": "ALL"
         },
         "openaddresses": {
           "datapath": "/data/openaddresses",
-          "files": ["us/ma/city_of_boston.csv"]
+          "files": []
         },
         "openstreetmap": {
           "download": [{
-              "sourceURL": "https://s3.amazonaws.com/metro-extracts.mapzen.com/boston_massachusetts.osm.pbf"
+              "sourceURL": "http://planet.us-east-1.mapzen.com/planet-latest.osm.pbf"
           }],
           "datapath": "/data/openstreetmap",
           "import": [{
-            "filename": "boston_massachusetts.osm.pbf"
+            "filename": "planet-latest.osm.pbf"
           }]
         },
         "polyline": {
@@ -65,9 +65,7 @@ data:
         },
         "whosonfirst": {
           "importVenues": false,
-          "importPlace": " 85950361",
-          "api_key": "{{ .Values.apiKey }}",
-          "datapath": "/data/whosonfirst/"
+          "datapath": "/data/whosonfirst"
         }
       }
     }

--- a/templates/configmap.tpl
+++ b/templates/configmap.tpl
@@ -12,6 +12,15 @@ data:
       },
       "api": {
         "services": {
+          "placeholder": {
+            "url": "http://pelias-placeholder-service:3102/"
+          },
+          "language": {
+            "url": "http://pelias-placeholder-service:3102/"
+          },
+          "interpolation": {
+            "url": "http://pelias-interpolation-service:3102/"
+          },
           "pip": {
             "url": "http://pelias-pip-service:3102/"
           }

--- a/templates/configmap.tpl
+++ b/templates/configmap.tpl
@@ -42,7 +42,8 @@ data:
         },
         "services": {
           "pip": {
-            "url": "http://pelias-pip-service:3102"
+            "url": "http://pelias-pip-service:3102",
+            "timeout": 5000
           }
         },
         "geonames": {

--- a/templates/configmap.tpl
+++ b/templates/configmap.tpl
@@ -29,7 +29,7 @@ data:
         }
       },
       "logger": {
-        "level": "debug",
+        "level": "info",
         "timestamp": true
       },
       "imports": {

--- a/templates/configmap.tpl
+++ b/templates/configmap.tpl
@@ -13,10 +13,7 @@ data:
       "api": {
         "services": {
           "placeholder": {
-            "url": "http://pelias-placeholder-service:3102/"
-          },
-          "language": {
-            "url": "http://pelias-placeholder-service:3102/"
+            "url": "http://pelias-placeholder-service:3000/"
           },
           "interpolation": {
             "url": "http://pelias-interpolation-service:3102/"

--- a/templates/configmap.tpl
+++ b/templates/configmap.tpl
@@ -13,13 +13,16 @@ data:
       "api": {
         "services": {
           "placeholder": {
-            "url": "http://pelias-placeholder-service:3000/"
+            "url": "http://pelias-placeholder-service:3000/",
+            "timeout": 5000
           },
           "interpolation": {
-            "url": "http://pelias-interpolation-service:3102/"
+            "url": "http://pelias-interpolation-service:3102/",
+            "timeout": 5000
           },
           "pip": {
-            "url": "http://pelias-pip-service:3102/"
+            "url": "http://pelias-pip-service:3102/",
+            "timeout": 5000
           }
         }
       },

--- a/templates/interpolation-deployment.tpl
+++ b/templates/interpolation-deployment.tpl
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: pelias-interpolation
 spec:
-  replicas: 1
+  replicas: {{ .Values.interpolationReplicas | default 1 }}
   template:
     metadata:
       labels:

--- a/templates/interpolation-deployment.tpl
+++ b/templates/interpolation-deployment.tpl
@@ -21,7 +21,7 @@ spec:
               mountPath: /data
       containers:
         - name: pelias-interpolation
-          image: pelias/interpolation:{{ .Values.interpolationDockerTag | default "production" }}
+          image: pelias/interpolation:{{ .Values.interpolationDockerTag | default "latest" }}
           volumeMounts:
             - name: data-volume
               mountPath: /data

--- a/templates/interpolation-deployment.tpl
+++ b/templates/interpolation-deployment.tpl
@@ -21,7 +21,7 @@ spec:
               mountPath: /data
       containers:
         - name: pelias-interpolation
-          image: pelias/interpolation
+          image: pelias/interpolation:{{ .Values.interpolationDockerTag | default "production" }}
           volumeMounts:
             - name: data-volume
               mountPath: /data

--- a/templates/interpolation-deployment.tpl
+++ b/templates/interpolation-deployment.tpl
@@ -27,9 +27,11 @@ spec:
               mountPath: /data
           resources:
             limits:
-              memory: 4Gi
-            requests:
               memory: 3Gi
+              cpu: 2
+            requests:
+              memory: 2Gi
+              cpu: 1
       volumes:
         - name: data-volume
           emptyDir: {}

--- a/templates/pip-deployment.tpl
+++ b/templates/pip-deployment.tpl
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: pelias-pip
 spec:
-  replicas: 1
+  replicas: {{ .Values.pipReplicas | default 1 }}
   template:
     metadata:
       labels:

--- a/templates/pip-deployment.tpl
+++ b/templates/pip-deployment.tpl
@@ -41,10 +41,10 @@ spec:
               value: "/etc/config/pelias.json"
           resources:
             limits:
-              memory: 9Gi
+              memory: 10Gi
               cpu: 3
             requests:
-              memory: 7Gi
+              memory: 9Gi
               cpu: 1.5
           readinessProbe:
             httpGet:

--- a/templates/pip-deployment.tpl
+++ b/templates/pip-deployment.tpl
@@ -21,6 +21,13 @@ spec:
           env:
             - name: PELIAS_CONFIG
               value: "/etc/config/pelias.json"
+          resources:
+            limits:
+              memory: 3Gi
+              cpu: 4
+            requests:
+              memory: 1Gi
+              cpu: 2
       containers:
         - name: pelias-pip
           image: pelias/pip-service:{{ .Values.pipDockerTag | default "production" }}
@@ -34,14 +41,16 @@ spec:
               value: "/etc/config/pelias.json"
           resources:
             limits:
-              memory: 8Gi
+              memory: 9Gi
+              cpu: 3
             requests:
-              memory: 4Gi
+              memory: 7Gi
+              cpu: 1.5
           readinessProbe:
             httpGet:
               path: /12/12
               port: 3102
-            initialDelaySeconds: 60 #PIP service takes a long time to start up
+            initialDelaySeconds: 120 #PIP service takes a long time to start up
       volumes:
         - name: config-volume
           configMap:

--- a/templates/pip-deployment.tpl
+++ b/templates/pip-deployment.tpl
@@ -11,7 +11,7 @@ spec:
     spec:
       initContainers:
         - name: wof-download
-          image: pelias/whosonfirst
+          image: pelias/pip-service:{{ .Values.pipDockerTag | default "production" }}
           command: ["npm", "run", "download"]
           volumeMounts:
             - name: config-volume
@@ -23,7 +23,7 @@ spec:
               value: "/etc/config/pelias.json"
       containers:
         - name: pelias-pip
-          image: pelias/pip-service:master
+          image: pelias/pip-service:{{ .Values.pipDockerTag | default "production" }}
           volumeMounts:
             - name: config-volume
               mountPath: /etc/config

--- a/templates/pip-deployment.tpl
+++ b/templates/pip-deployment.tpl
@@ -11,7 +11,7 @@ spec:
     spec:
       initContainers:
         - name: wof-download
-          image: pelias/pip-service:{{ .Values.pipDockerTag | default "production" }}
+          image: pelias/pip-service:{{ .Values.pipDockerTag | default "latest" }}
           command: ["npm", "run", "download"]
           volumeMounts:
             - name: config-volume
@@ -30,7 +30,7 @@ spec:
               cpu: 2
       containers:
         - name: pelias-pip
-          image: pelias/pip-service:{{ .Values.pipDockerTag | default "production" }}
+          image: pelias/pip-service:{{ .Values.pipDockerTag | default "latest" }}
           volumeMounts:
             - name: config-volume
               mountPath: /etc/config

--- a/templates/placeholder-deployment.tpl
+++ b/templates/placeholder-deployment.tpl
@@ -28,7 +28,7 @@ spec:
               cpu: 1
       containers:
         - name: pelias-placeholder
-          image: pelias/placeholder:{{ .Values.placeholderDockerTag | default "production" }}
+          image: pelias/placeholder:{{ .Values.placeholderDockerTag | default "latest" }}
           volumeMounts:
             - name: data-volume
               mountPath: /data

--- a/templates/placeholder-deployment.tpl
+++ b/templates/placeholder-deployment.tpl
@@ -19,6 +19,13 @@ spec:
           volumeMounts:
             - name: data-volume
               mountPath: /data
+          resources:
+            limits:
+              memory: 1Gi
+              cpu: 2
+            requests:
+              memory: 512Mi
+              cpu: 1
       containers:
         - name: pelias-placeholder
           image: pelias/placeholder:{{ .Values.placeholderDockerTag | default "production" }}

--- a/templates/placeholder-deployment.tpl
+++ b/templates/placeholder-deployment.tpl
@@ -14,7 +14,6 @@ spec:
           image: busybox
           command: ["sh", "-c",
             "mkdir -p /data/placeholder/ &&\n
-             wget -O- http://pelias-data.s3.amazonaws.com/placeholder/graph.json.gz | gunzip > /data/placeholder/graph.json &\n
              wget -O- http://pelias-data.s3.amazonaws.com/placeholder/store.sqlite3.gz | gunzip > /data/placeholder/store.sqlite3" ]
           volumeMounts:
             - name: data-volume

--- a/templates/placeholder-deployment.tpl
+++ b/templates/placeholder-deployment.tpl
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: pelias-placeholder
 spec:
-  replicas: 1
+  replicas: {{ .Values.placeholderReplicas | default 1 }}
   template:
     metadata:
       labels:

--- a/templates/placeholder-deployment.tpl
+++ b/templates/placeholder-deployment.tpl
@@ -21,7 +21,7 @@ spec:
               mountPath: /data
       containers:
         - name: pelias-placeholder
-          image: pelias/placeholder
+          image: pelias/placeholder:{{ .Values.placeholderDockerTag | default "production" }}
           volumeMounts:
             - name: data-volume
               mountPath: /data


### PR DESCRIPTION
This PR adds support for full planet builds within Kubernetes, using all 5 importers.

It requires quite a bit of hardware of course, but with proper resource limits it is no problem at all for Kubernetes to handle.

Numerous tweaks had to be made to support this and are included in this repo.