### PR TITLE
Enable pelias dashboard

### DIFF
--- a/templates/dashboard-deployment.yaml
+++ b/templates/dashboard-deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: pelias-dashboard
+spec:
+  replicas: {{ .Values.dashboardReplicas | default 1 }}
+  minReadySeconds: 30 #kubernetes operates so fast it can be nice to slow things down a little
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: pelias-dashboard
+    spec:
+      containers:
+        - name: pelias-adashboard
+          image: pelias/dashboard:{{ .Values.dashboardDockerTag | default "latest" }}
+          env:
+            - name: AUTH_TOKEN
+              value: "foo"
+            - name: ES_ENDPOINT
+              value: "http://{{ .Values.elasticsearchHost }}:9200/"
+          resources:
+            limits:
+              memory: 0.2Gi
+              cpu: 0.25
+            requests:
+              memory: 0.2Gi
+              cpu: 0.25

--- a/templates/dashboard-service.yaml
+++ b/templates/dashboard-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+    name: pelias-dashboard-service
+spec:
+    selector:
+        app: pelias-dashboard
+    ports:
+        - protocol: TCP
+          port: 3030
+    type: ClusterIP

--- a/values.yaml
+++ b/values.yaml
@@ -4,3 +4,6 @@ elasticsearchHost: "elasticsearch-service"
 # Whether the API service should be externally accessible
 # Set this to true if you want to, for example on AWS, set up an ELB for the API
 externalAPIService: false
+
+# Whether the dashboard should be set up
+dashboardEnabled: false


### PR DESCRIPTION
This allows the [Pelias dashboard](https://github.com/pelias/dashboard) to be set up in Kubernetes.