### PR TITLE
Add the ability to configure the Elasticsearch index name

### DIFF
--- a/templates/configmap.tpl
+++ b/templates/configmap.tpl
@@ -11,6 +11,7 @@ data:
         }]
       },
       "api": {
+        "indexName": "{{ .Values.apiIndexName }}",
         "services": {
           "placeholder": {
             "url": "{{ .Values.placeholderHost }}",

--- a/values.yaml
+++ b/values.yaml
@@ -7,6 +7,9 @@ externalAPIService: false
 # whether this ELB should be internet facing or private (default private)
 privateAPILoadBalancer: true
 
+# the name of the Elasticsearch index to use
+apiIndexName: "pelias"
+
 # Whether the dashboard should be set up
 dashboardEnabled: false
 


### PR DESCRIPTION
This is rarely needed, but can be useful if the standard "pelias"
Elasticsearch index name is not being used.