### PR TITLE
Properly setup AMI tag filter

### DIFF
--- a/elasticsearch/terraform/ami.tf
+++ b/elasticsearch/terraform/ami.tf
@@ -7,6 +7,6 @@ data "aws_ami" "elasticsearch_ami" {
 
   filter {
     name   = "tag:env"
-    values = ["production"]
+    values = ["${var.ami_env_tag_filter}"]
   }
 }


### PR DESCRIPTION
It is now possible to filter AMIs used to launch the Elasticsearch
instances by a tag. Previously, filtering was done based on a hardcoded
value. A variable to allow configuring the value to filter by existed,
but was not used.

Now it's used, and filtering works properly!