### PR TITLE
Service flags and configurable retries/timeouts

### DIFF
--- a/templates/configmap.tpl
+++ b/templates/configmap.tpl
@@ -17,24 +17,28 @@ data:
          {{ if .Values.placeholderEnabled  }}
           "placeholder": {
             "url": "{{ .Values.placeholderHost }}",
-            "timeout": 5000
+            "retries": {{ .Values.placeholderRetries | default 1 }},
+            "timeout": {{ .Values.placeholderTimeout | default 5000 }}
           },
          {{ end }}
           {{ if .Values.interpolationEnabled }}
           "interpolation": {
             "url": "{{ .Values.interpolationHost }}",
-            "timeout": 5000
+            "retries": {{ .Values.interpolationRetries | default 1 }},
+            "timeout": {{ .Values.interpolationTimeout | default 5000 }}
           },
           {{ end }}
           {{ if .Values.pipEnabled }}
           "pip": {
             "url": "{{ .Values.pipHost }}",
-              "timeout": 5000
+            "retries": {{ .Values.pipRetries | default 1 }},
+            "timeout": {{ .Values.pipTimeout | default 5000 }}
           },
           {{ end }}
           "libpostal": {
             "url": "{{ .Values.libpostalHost }}",
-              "timeout": 5000
+            "retries": {{ .Values.libpostalRetries | default 1 }},
+            "timeout": {{ .Values.libpostalTimeout | default 5000 }}
           } # for now, as a hack, libpostal cannot be disabled because there needs to be no comma only on the LAST element of a JSON object
         }
       },

--- a/templates/configmap.tpl
+++ b/templates/configmap.tpl
@@ -20,7 +20,7 @@ data:
             "timeout": 5000
           },
          {{ end }}
-          {{ if ne .Values.interpolationReplicas "0" }}
+          {{ if .Values.interpolationEnabled }}
           "interpolation": {
             "url": "{{ .Values.interpolationHost }}",
             "timeout": 5000

--- a/templates/configmap.tpl
+++ b/templates/configmap.tpl
@@ -14,7 +14,7 @@ data:
         "attributionURL": "{{ .Values.apiAttributionURL }}",
         "indexName": "{{ .Values.apiIndexName }}",
         "services": {
-         {{ if ne .Values.placeholderReplicas "0" }}
+         {{ if .Values.placeholderEnabled  }}
           "placeholder": {
             "url": "{{ .Values.placeholderHost }}",
             "timeout": 5000
@@ -26,14 +26,19 @@ data:
             "timeout": 5000
           },
           {{ end }}
+          {{ if .Values.libpostalEnabled }}
           "libpostal": {
             "url": "{{ .Values.libpostalHost }}",
-            "timeout": 5000
+              "timeout": 5000
           },
+            {{ end }}
+          {{ if .Values.pipEnabled }}
           "pip": {
             "url": "{{ .Values.pipHost }}",
-            "timeout": 5000
-          }
+              "timeout": 5000
+          },
+          {{ end }}
+          { }
         }
       },
       "acceptance-tests": {

--- a/templates/configmap.tpl
+++ b/templates/configmap.tpl
@@ -26,19 +26,16 @@ data:
             "timeout": 5000
           },
           {{ end }}
-          {{ if .Values.libpostalEnabled }}
-          "libpostal": {
-            "url": "{{ .Values.libpostalHost }}",
-              "timeout": 5000
-          },
-            {{ end }}
           {{ if .Values.pipEnabled }}
           "pip": {
             "url": "{{ .Values.pipHost }}",
               "timeout": 5000
           },
           {{ end }}
-          { }
+          "libpostal": {
+            "url": "{{ .Values.libpostalHost }}",
+              "timeout": 5000
+          } # for now, as a hack, libpostal cannot be disabled because there needs to be no comma only on the LAST element of a JSON object
         }
       },
       "acceptance-tests": {

--- a/templates/configmap.tpl
+++ b/templates/configmap.tpl
@@ -39,7 +39,7 @@ data:
             "url": "{{ .Values.libpostalHost }}",
             "retries": {{ .Values.libpostalRetries | default 1 }},
             "timeout": {{ .Values.libpostalTimeout | default 5000 }}
-          } # for now, as a hack, libpostal cannot be disabled because there needs to be no comma only on the LAST element of a JSON object
+          }
         }
       },
       "acceptance-tests": {

--- a/values.yaml
+++ b/values.yaml
@@ -19,6 +19,9 @@ interpolationHost: "http://pelias-interpolation-service:3000/"
 libpostalHost: "http://pelias-libpostal-service:8080/"
 pipHost: "http://pelias-pip-service:3102/"
 
+libpostalEnabled: true
+placeholderEnabled: true
+pipEnabled: true
 interpolationEnabled: false
 
 placeholderStoreURL: "https://s3.amazonaws.com/geocodeearth-pelias-data/placeholder/store.sqlite3.gz"

--- a/values.yaml
+++ b/values.yaml
@@ -19,4 +19,6 @@ interpolationHost: "http://pelias-interpolation-service:3000/"
 libpostalHost: "http://pelias-libpostal-service:8080/"
 pipHost: "http://pelias-pip-service:3102/"
 
+interpolationEnabled: false
+
 placeholderStoreURL: "https://s3.amazonaws.com/geocodeearth-pelias-data/placeholder/store.sqlite3.gz"


### PR DESCRIPTION
Switch to using dedicated boolean values for whether or not services are enabled.

Trying to "guess" based on the replica count for service deployments is both confusing and not flexible enough. Sometimes, you want to disable a service temporarily, but leave its pods running, since many Pelias services take significant time to start up.

Additionally, all retry and timeout values are now configurable.