### PR TITLE
Improve Pip and Interpolation service helm configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,30 @@ it can be useful to open a shell inside a running container for debugging:
 # kubectl exec -it {{pod_name}} -- {{command}}
 kubectl exec -it pelias-pip-3625698757-dtzmd -- /bin/bash
 ```
+
+# Helm Chart Configuration
+The following table lists common configurable parameters of the chart and
+their default values. See values.yaml for all available options.
+
+|       Parameter                        |           Description                       |                         Default                     |
+|----------------------------------------|---------------------------------------------|-----------------------------------------------------|
+| `elasticsearch.host`                   | Elasticsearch hostname                      | `elasticsearch-service`                                              |
+| `elasticsearch.port`                   | Elasticsearch access port                   | `9200`                                              |
+| `elasticsearch.protocol`               | Elasticsearch access protocol               | `http`                                              |
+| `elasticsearch.auth`                   | Elasticsearch authentication `user:pass`    | `-`                                              |
+| `pip.enabled`                          | Whether to enable pip service               | `true`                                              |
+| `pip.host`                             | Pip service url                             | `http://pelias-pip-service:3102/`                   |
+| `pip.pvc.create`                       | To use a custom PVC                         | `-`                                                 |
+| `pip.pvc.name`                         | Name of the PVC                             | `-`                                                 |
+| `pip.pvc.storageClass`                 | Storage Class to use for PVC	               | `-`                                                 |
+| `pip.pvc.storage`                      | Amount of space to claim for PVC	           | `-`                                                 |
+| `pip.pvc.annotations`                  | Storage Class annotation for PVC	           | `-`                                                 |
+| `pip.pvc.accessModes`                  | Access mode to use for PVC      	           | `-`                                                 |
+| `interpolation.enabled`                | Whether to enable interpolation service     | `false`                                             |
+| `interpolation.host`                   | Pip service url                             | `http://pelias-interpolation-service:3000/`           |
+| `interpolation.pvc.create`             | To use a custom PVC                         | `-`                                                 |
+| `interpolation.pvc.name`               | Name of the PVC                             | `-`                                                 |
+| `interpolation.pvc.storageClass`       | Storage Class to use for PVC	               | `-`                                                 |
+| `interpolation.pvc.storage`            | Amount of space to claim for PVC	           | `-`                                                 |
+| `interpolation.pvc.annotations`        | Storage Class annotation for PVC	           | `-`                                                 |
+| `interpolation.pvc.accessModes`        | Access mode to use for PVC      	           | `-`                                                 |

--- a/templates/configmap.tpl
+++ b/templates/configmap.tpl
@@ -28,27 +28,27 @@ data:
         "attributionURL": "{{ .Values.apiAttributionURL }}",
         "indexName": "{{ .Values.apiIndexName }}",
         "services": {
-         {{ if .Values.placeholderEnabled  }}
+          {{ if .Values.placeholderEnabled  }}
           "placeholder": {
             "url": "{{ .Values.placeholderHost }}",
             "retries": {{ .Values.placeholderRetries | default 1 }},
             "timeout": {{ .Values.placeholderTimeout | default 5000 }}
           },
-         {{ end }}
-          {{ if .Values.interpolationEnabled }}
+          {{- end }}
+          {{- if .Values.interpolationEnabled | default .Values.interpolation.enabled }}
           "interpolation": {
-            "url": "{{ .Values.interpolationHost }}",
+            "url": "{{ .Values.interpolationHost | default .Values.interpolation.host }}",
             "retries": {{ .Values.interpolationRetries | default 1 }},
             "timeout": {{ .Values.interpolationTimeout | default 5000 }}
           },
-          {{ end }}
-          {{ if .Values.pipEnabled }}
+          {{- end }}
+          {{- if .Values.pipEnabled | default .Values.pip.enabled }}
           "pip": {
-            "url": "{{ .Values.pipHost }}",
+            "url": "{{ .Values.pipHost | default .Values.pip.host}}",
             "retries": {{ .Values.pipRetries | default 1 }},
             "timeout": {{ .Values.pipTimeout | default 5000 }}
           },
-          {{ end }}
+          {{- end }}
           "libpostal": {
             "url": "{{ .Values.libpostalHost }}",
             "retries": {{ .Values.libpostalRetries | default 1 }},

--- a/templates/interpolation-deployment.tpl
+++ b/templates/interpolation-deployment.tpl
@@ -1,3 +1,4 @@
+{{- if (or (.Values.interpolationEnabled) (.Values.interpolation.enabled))  }}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -41,4 +42,10 @@ spec:
               cpu: 0.1
       volumes:
         - name: data-volume
+        {{- if .Values.interpolation.pvc.create }}
+          persistentVolumeClaim:
+          claimName: {{ .Values.interpolation.pvc.name }}
+        {{- else }}
           emptyDir: {}
+        {{- end }}
+{{- end -}}

--- a/templates/interpolation-pvc.yaml
+++ b/templates/interpolation-pvc.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.interpolation.pvc.create }}
+{{- if (or (.Values.interpolationEnabled) (.Values.interpolation.enabled))  }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ .Values.interpolation.pvc.name }}
+  annotations:
+    {{- range $key, $value := .Values.interpolation.pvc.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  storageClassName: {{ .Values.interpolation.pvc.storageClass }}
+  accessModes:
+    - {{ .Values.interpolation.pvc.accessModes }}
+  resources:
+    requests:
+      storage: {{ .Values.interpolation.pvc.storage }}
+{{- end -}}
+{{- end -}}

--- a/templates/interpolation-service.tpl
+++ b/templates/interpolation-service.tpl
@@ -1,3 +1,4 @@
+{{- if (or (.Values.interpolationEnabled) (.Values.interpolation.enabled))  }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -9,3 +10,4 @@ spec:
         - protocol: TCP
           port: 3000
     type: ClusterIP
+{{- end -}}

--- a/templates/pip-deployment.tpl
+++ b/templates/pip-deployment.tpl
@@ -1,3 +1,4 @@
+{{- if (or (.Values.pipEnabled) (.Values.pip.enabled)) }}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -64,4 +65,10 @@ spec:
               - key: pelias.json
                 path: pelias.json
         - name: data-volume
+          {{- if .Values.pip.pvc.create }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.pip.pvc.name }}
+          {{- else }}
           emptyDir: {}
+          {{- end }}
+{{- end -}}

--- a/templates/pip-pvc.yaml
+++ b/templates/pip-pvc.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.pip.pvc.create }}
+{{- if (or (.Values.pipEnabled) (.Values.pip.enabled)) }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ .Values.pip.pvc.name }}
+  annotations:
+    {{- range $key, $value := .Values.pip.pvc.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  storageClassName: {{ .Values.pip.pvc.storageClass }}
+  accessModes:
+    - {{ .Values.pip.pvc.accessModes }}
+  resources:
+    requests:
+      storage: {{ .Values.pip.pvc.storage }}
+{{- end -}}
+{{- end -}}

--- a/templates/pip-service.tpl
+++ b/templates/pip-service.tpl
@@ -1,3 +1,4 @@
+{{- if (or (.Values.pipEnabled) (.Values.pip.enabled)) }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -9,3 +10,4 @@ spec:
         - protocol: TCP
           port: 3102
     type: ClusterIP
+{{- end -}}

--- a/values.yaml
+++ b/values.yaml
@@ -18,13 +18,39 @@ apiAttributionURL: "http://api.yourpelias.com/attribution"
 dashboardEnabled: false
 
 placeholderHost: "http://pelias-placeholder-service:3000/"
-interpolationHost: "http://pelias-interpolation-service:3000/"
 libpostalHost: "http://pelias-libpostal-service:8080/"
-pipHost: "http://pelias-pip-service:3102/"
 
 libpostalEnabled: true
 placeholderEnabled: true
-pipEnabled: true
-interpolationEnabled: false
 
 placeholderStoreURL: "https://s3.amazonaws.com/pelias-data.nextzen.org/placeholder/store.sqlite3.gz"
+
+interpolation:
+  enabled: false
+  host: "http://pelias-interpolation-service:3000/"
+  pvc: {}
+#    create: true
+#    name: interpolation-pvc
+#    storageClass: aws-efs
+#    accessModes: ReadWriteMany
+#    storage: 10Gi
+#    annotations: {}
+
+pip:
+  enabled: true
+  host: "http://pelias-pip-service:3102/"
+  pvc: {}
+#    create: true
+#    name: pip-pvc
+#    storageClass: aws-efs
+#    accessModes: ReadWriteMany
+#    storage: 10Gi
+#    annotations: {}
+
+
+# Deprecated fields
+# pipEnabled: true
+# pipHost: "http://pelias-pip-service:3102/"
+
+# interpolationEnabled: false
+# interpolationHost: "http://pelias-interpolation-service:3000/"


### PR DESCRIPTION
- Change values to map structure
- Not create deployment and service if service is not enabled
- Allow Pip and Interpolation service to use PVC like EBS or AWS EFS