### PR TITLE
fix(schema): use correct docker tagwhen creating schema

### DIFF
--- a/build/templates/schema-create-job.tpl
+++ b/build/templates/schema-create-job.tpl
@@ -21,7 +21,7 @@ spec:
       {{ end }}
       containers:
       - name: schema-create
-        image: pelias/schema
+        image: pelias/schema:{{ .Values.schemaDockerTag | default "latest" }}
         command: ["npm", "run", "create_index"]
         volumeMounts:
           - name: config-volume


### PR DESCRIPTION
The correct tag was being used when _deleting_ the old schema, but not creating the new one 😨 