### PR TITLE
Support loading Elasticsearch snapshots

### DIFF
--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -119,7 +119,6 @@ module "elasticsearch-prod-a" {
   ssh_key_name = "ssh-key-to-use"
 
   environment                       = "dev" # or whatever unique environment you choose
-  snapshot_s3_bucket_arn            = "arn:aws:s3:::pelias-elasticsearch.nextzen.org"
   elasticsearch_max_instances       = 4 # 4 r4.xlarge instances is suitable for a minimal full-planet production build with replicas
   elasticsearch_min_instances       = 4
   elasticsearch_desired_instances   = 4
@@ -129,6 +128,13 @@ module "elasticsearch-prod-a" {
   ssh_ip_range                      = "172.20.0.0/16" # adjust this if you'd like SSH access to be limited, or remove if you don't want that
   ami_env_tag_filter                = "prod" # this variable can be adjusted if you tag your AMIs differently, or removed to use the latest AMI
   subnet_name_filter                = "us-east-*" # if you only want to launch Elasticsearch instances in some subnets, provide a filter to find the subnets. Remove if all subnets are ok
+
+  # the following section is all optional, and if configured, will load an existing snapshot from S3 on startup
+  snapshot_s3_bucket                = "pelias-elasticsearch.nextzen.org"
+  snapshot_name                     = "name-of-your-snapshot"  # required to load snapshot
+  snapshot_base_path                = "path/to/your/snapshot"  # required to load snapshot
+  snapshot_alias_name               = "pelias"                 # if you'd like an alias created, use this variable
+  snapshot_replica_count            = 1                        # 1 is the default, modify as desired
 }
 ```
 

--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -113,22 +113,22 @@ Create a file, for example `elasticsearch.tf`, with contents like the following:
 
 ```hcl
 module "elasticsearch-prod-a" {
-	source = "github.com/pelias/kubernetes//elasticsearch/terraform?ref=v1.5.2"
+  source = "github.com/pelias/kubernetes//elasticsearch/terraform?ref=v1.5.2"
 
-	aws_vpc_id   = "vpc-1234" # the ID of an existing VPC in which to create the instances
-	ssh_key_name = "ssh-key-to-use"
+  aws_vpc_id   = "vpc-1234" # the ID of an existing VPC in which to create the instances
+  ssh_key_name = "ssh-key-to-use"
 
-	environment                       = "dev" # or whatever unique environment you choose
-	snapshot_s3_bucket_arn            = "arn:aws:s3:::pelias-elasticsearch.nextzen.org"
-	elasticsearch_max_instances       = 4 # 4 r4.xlarge instances is suitable for a minimal full-planet production build with replicas
-	elasticsearch_min_instances       = 4
-	elasticsearch_desired_instances   = 4
-	elasticsearch_data_volume_size    = 300
-	elasticsearch_instance_type       = "r4.xlarge"
-	elasticsearch_heap_memory_percent = 50
-	ssh_ip_range                      = "172.20.0.0/16" # adjust this if you'd like SSH access to be limited, or remove if you don't want that
-	ami_env_tag_filter                = "prod" # this variable can be adjusted if you tag your AMIs differently, or removed to use the latest AMI
-	subnet_name_filter                = "us-east-*" # if you only want to launch Elasticsearch instances in some subnets, provide a filter to find the subnets. Remove if all subnets are ok
+  environment                       = "dev" # or whatever unique environment you choose
+  snapshot_s3_bucket_arn            = "arn:aws:s3:::pelias-elasticsearch.nextzen.org"
+  elasticsearch_max_instances       = 4 # 4 r4.xlarge instances is suitable for a minimal full-planet production build with replicas
+  elasticsearch_min_instances       = 4
+  elasticsearch_desired_instances   = 4
+  elasticsearch_data_volume_size    = 300
+  elasticsearch_instance_type       = "r4.xlarge"
+  elasticsearch_heap_memory_percent = 50
+  ssh_ip_range                      = "172.20.0.0/16" # adjust this if you'd like SSH access to be limited, or remove if you don't want that
+  ami_env_tag_filter                = "prod" # this variable can be adjusted if you tag your AMIs differently, or removed to use the latest AMI
+  subnet_name_filter                = "us-east-*" # if you only want to launch Elasticsearch instances in some subnets, provide a filter to find the subnets. Remove if all subnets are ok
 }
 ```
 

--- a/elasticsearch/terraform/cloud_init.tf
+++ b/elasticsearch/terraform/cloud_init.tf
@@ -15,6 +15,19 @@ data "template_file" "setup" {
   }
 }
 
+data "template_file" "load_snapshot" {
+  template = "${file("${path.module}/templates/load_snapshot.sh.tpl")}"
+
+  vars {
+    snapshot_s3_bucket = "${var.snapshot_s3_bucket}"
+    snapshot_base_path = "${var.snapshot_base_path}"
+    snapshot_name = "${var.snapshot_name}"
+    snapshot_replica_count = "${var.snapshot_replica_count}"
+    snapshot_alias_name = "${var.snapshot_alias_name}"
+    snapshot_repository_read_only = "${var.snapshot_repository_read_only}"
+  }
+}
+
 data "template_cloudinit_config" "cloud_init" {
   gzip = true
   base64_encode = true
@@ -22,5 +35,10 @@ data "template_cloudinit_config" "cloud_init" {
   part {
     content_type = "text/x-shellscript"
     content      = "${data.template_file.setup.rendered}"
+  }
+
+  part {
+    content_type = "text/x-shellscript"
+    content      = "${data.template_file.load_snapshot.rendered}"
   }
 }

--- a/elasticsearch/terraform/cloud_init.tf
+++ b/elasticsearch/terraform/cloud_init.tf
@@ -1,0 +1,26 @@
+data "template_file" "setup" {
+  template = "${file("${path.module}/templates/setup.sh.tpl")}"
+
+  vars {
+    elasticsearch_data_dir            = "${var.elasticsearch_data_dir}"
+    elasticsearch_log_dir             = "${var.elasticsearch_log_dir}"
+    es_cluster_name                   = "${var.service_name}-${var.environment}-elasticsearch"
+    es_allowed_urls                   = "${var.es_allowed_urls}"
+    aws_security_group                = "${aws_security_group.elasticsearch.id}"
+    aws_region                        = "${var.aws_region}"
+    availability_zones                = "${var.availability_zones}"
+    expected_nodes                    = "${var.elasticsearch_desired_instances}"
+    minimum_master_nodes              = "${var.elasticsearch_desired_instances/2 + 1}"
+    elasticsearch_heap_memory_percent = "${var.elasticsearch_heap_memory_percent}"
+  }
+}
+
+data "template_cloudinit_config" "cloud_init" {
+  gzip = true
+  base64_encode = true
+
+  part {
+    content_type = "text/x-shellscript"
+    content      = "${data.template_file.setup.rendered}"
+  }
+}

--- a/elasticsearch/terraform/iam.tf
+++ b/elasticsearch/terraform/iam.tf
@@ -20,7 +20,7 @@ data "template_file" "s3_policy" {
   template = "${file("${path.module}/templates/s3_policy.json.tpl")}"
 
   vars {
-    snapshot_s3_bucket_arn = "${var.snapshot_s3_bucket_arn}"
+    snapshot_s3_bucket = "${var.snapshot_s3_bucket}"
   }
 }
 

--- a/elasticsearch/terraform/main.tf
+++ b/elasticsearch/terraform/main.tf
@@ -1,20 +1,3 @@
-data "template_file" "user_data" {
-  template = "${file("${path.module}/templates/user-data.tpl")}"
-
-  vars {
-    elasticsearch_data_dir            = "${var.elasticsearch_data_dir}"
-    elasticsearch_log_dir             = "${var.elasticsearch_log_dir}"
-    es_cluster_name                   = "${var.service_name}-${var.environment}-elasticsearch"
-    es_allowed_urls                   = "${var.es_allowed_urls}"
-    aws_security_group                = "${aws_security_group.elasticsearch.id}"
-    aws_region                        = "${var.aws_region}"
-    availability_zones                = "${var.availability_zones}"
-    expected_nodes                    = "${var.elasticsearch_desired_instances}"
-    minimum_master_nodes              = "${var.elasticsearch_desired_instances/2 + 1}"
-    elasticsearch_heap_memory_percent = "${var.elasticsearch_heap_memory_percent}"
-  }
-}
-
 resource "aws_launch_configuration" "elasticsearch" {
   name_prefix                 = "${var.service_name}-${var.environment}-elasticsearch-"
   image_id                    = "${data.aws_ami.elasticsearch_ami.id}"
@@ -25,7 +8,7 @@ resource "aws_launch_configuration" "elasticsearch" {
   # use EBS optimized instances unless launching at t2 instance
   ebs_optimized        = "${format("%.1s", var.elasticsearch_instance_type) == "t" ? false : true}"
   key_name             = "${var.ssh_key_name}"
-  user_data            = "${data.template_file.user_data.rendered}"
+  user_data            = "${data.template_cloudinit_config.cloud_init.rendered}"
   iam_instance_profile = "${aws_iam_instance_profile.elasticsearch.arn}"
 
   lifecycle {

--- a/elasticsearch/terraform/templates/load_snapshot.sh.tpl
+++ b/elasticsearch/terraform/templates/load_snapshot.sh.tpl
@@ -34,8 +34,15 @@ until test $(elastic_status) -eq 200; do
   sleep 2
 done
 
-# All commands below are idempotent, so even though every node on this cluster
-# will run all commands, it will work fine
+# check if this node is the master node
+cluster_url="http://localhost:9200"
+
+if $(curl -s "$cluster_url/_cat/master" | grep -q `hostname`); then
+  echo "this is the master node, loading snapshot"
+else
+  echo "this is not the master, aborting snapshot load"
+  exit 0
+fi
 
 ## 1. set proper settings
 echo "setting optimal index recovery settings for higher performance on $cluster_url"

--- a/elasticsearch/terraform/templates/load_snapshot.sh.tpl
+++ b/elasticsearch/terraform/templates/load_snapshot.sh.tpl
@@ -1,0 +1,97 @@
+#!/bin/bash
+set -euo pipefail
+
+
+# set variables, convert terraform variables to variables used by this shell script
+cluster_url="http://localhost:9200"
+es_repo_name="initial_snapshot"
+s3_bucket="${snapshot_s3_bucket}"
+base_path="${snapshot_base_path}"
+snapshot_name="${snapshot_name}"
+read_only="${snapshot_repository_read_only}"
+alias_name="${snapshot_alias_name}"
+replica_count="${snapshot_replica_count}"
+
+# check all required variables are set
+if [[ "$snapshot_name" == "" ]]; then
+  echo "snapshot_name not set, no snapshot will be loaded"
+  exit 0
+fi
+
+if [[ "$s3_bucket" == "" ]]; then
+  echo "s3_bucket not set, no snapshot will be loaded"
+  exit 0
+fi
+
+## 0. wait for elasticsearch to become ready
+function elastic_status(){
+  curl --output /dev/null --silent --write-out "%{http_code}" "$cluster_url" || true;
+}
+
+echo "waiting for elasticsearch on $cluster_url"
+until test $(elastic_status) -eq 200; do
+  printf '.'
+  sleep 2
+done
+
+# All commands below are idempotent, so even though every node on this cluster
+# will run all commands, it will work fine
+
+## 1. set proper settings
+echo "setting optimal index recovery settings for higher performance on $cluster_url"
+curl -XPUT "$cluster_url/_cluster/settings" -d '{
+  "persistent": {
+    "indices.recovery.max_bytes_per_sec": "4000mb",
+      "cluster.routing.allocation.node_concurrent_recoveries": 24,
+      "cluster.routing.allocation.node_initial_primaries_recoveries": 24
+  }
+}'
+echo
+
+## 2. create snapshot repository
+curl -s -XPOST "$cluster_url/_snapshot/$es_repo_name" -d "{
+  \"type\": \"s3\",
+    \"settings\": {
+      \"bucket\": \"$s3_bucket\",
+      \"readonly\": $read_only,
+      \"base_path\" : \"$base_path\",
+      \"max_snapshot_bytes_per_sec\" : \"1000mb\",
+      \"max_restore_bytes_per_sec\" : \"1000mb\"
+    }
+}"
+echo
+
+## 3. import snapshot
+curl -s -XPOST "$cluster_url/_snapshot/$es_repo_name/$snapshot_name/_restore" -d "{
+  \"indices\": \"pelias\",
+    \"rename_pattern\": \"pelias\",
+    \"rename_replacement\": \"$snapshot_name\"
+}"
+
+## 4. make alias if alias_name set
+
+if [[ "$alias_name" != "" ]]; then
+  echo "creating $alias_name alias pointing to $snapshot_name on $cluster_url"
+
+  curl -s -XPOST "$cluster_url/_aliases" -d "{
+    \"actions\": [{
+      \"add\": {
+        \"index\": \"$snapshot_name\",
+        \"alias\": \"$alias_name\"
+      }
+    }]
+  }"
+  echo
+else
+  echo "no alias_name set, will not create alias"
+fi
+
+## 5. set replica count
+echo "setting replica count to $replica_count on $snapshot_name index in $cluster_url"
+
+curl -s -XPUT "$cluster_url/$snapshot_name/_settings" -d "{
+  \"index\" : {
+    \"number_of_replicas\" : $replica_count
+  }
+}"
+echo

--- a/elasticsearch/terraform/templates/s3_policy.json.tpl
+++ b/elasticsearch/terraform/templates/s3_policy.json.tpl
@@ -7,7 +7,7 @@
         "s3:ListBucket"
       ],
       "Resource": [
-        "${snapshot_s3_bucket_arn}"
+        "arn:aws:s3:::${snapshot_s3_bucket}"
       ]
     },
     {
@@ -19,7 +19,7 @@
         "s3:PutObjectAcl"
       ],
       "Resource": [
-        "${snapshot_s3_bucket_arn}/*"
+        "arn:aws:s3:::${snapshot_s3_bucket}/*"
       ]
     }
   ]

--- a/elasticsearch/terraform/templates/setup.sh.tpl
+++ b/elasticsearch/terraform/templates/setup.sh.tpl
@@ -7,7 +7,7 @@ set -e
 
 cat <<'EOF' >/etc/elasticsearch/elasticsearch.yml
 cluster.name: ${es_cluster_name}
-node.name: $${HOSTNAME}
+node.name: $${HOSTNAME} # the $${HOSTNAME} var is filled in by Elasticsearch
 
 # our init.d script sets the default to this as well
 path.data: ${elasticsearch_data_dir}

--- a/elasticsearch/terraform/templates/user-data.tpl
+++ b/elasticsearch/terraform/templates/user-data.tpl
@@ -14,7 +14,8 @@ path.data: ${elasticsearch_data_dir}
 path.logs: ${elasticsearch_log_dir}
 
 bootstrap.mlockall: true
-network.host: _ec2:privateIpv4_
+network.host: [ '_ec2:privateIpv4_', _local_ ]
+network.publish_host: '_ec2:privateIpv4_'
 discovery.type: ec2
 discovery.zen.minimum_master_nodes: ${minimum_master_nodes}
 discovery.ec2.groups: ${aws_security_group}

--- a/elasticsearch/terraform/templates/user-data.tpl
+++ b/elasticsearch/terraform/templates/user-data.tpl
@@ -7,7 +7,7 @@ set -e
 
 cat <<'EOF' >/etc/elasticsearch/elasticsearch.yml
 cluster.name: ${es_cluster_name}
-#TODO: set node.name from hostname
+node.name: $${HOSTNAME}
 
 # our init.d script sets the default to this as well
 path.data: ${elasticsearch_data_dir}

--- a/elasticsearch/terraform/variables.tf
+++ b/elasticsearch/terraform/variables.tf
@@ -98,8 +98,34 @@ variable "es_allowed_urls" {
   default     = ""
 }
 
+## snapshot loading settings
 variable "snapshot_s3_bucket" {
   description = "The bucket where ES snapshots can be loaded from S3."
+}
+
+variable "snapshot_base_path" {
+  description = "The path within the snapshot repository where the snapshot to load is found"
+  default = ""
+}
+
+variable "snapshot_name" {
+  description = "The name of the snapshot to load from S3. If blank, no snapshot will be loaded"
+  default = ""
+}
+
+variable "snapshot_replica_count" {
+  description = "The number of replicas to add to the loaded snapshot. Default 1"
+  default = "1"
+}
+
+variable "snapshot_alias_name" {
+  description = "The alias to give to the loaded snapshot. None made if blank"
+  default = ""
+}
+
+variable "snapshot_repository_read_only" {
+  description = "Whether the snapshot repository is read_only. Default true"
+  default = "true"
 }
 
 # General settings

--- a/elasticsearch/terraform/variables.tf
+++ b/elasticsearch/terraform/variables.tf
@@ -98,8 +98,8 @@ variable "es_allowed_urls" {
   default     = ""
 }
 
-variable "snapshot_s3_bucket_arn" {
-  description = "The ARN where ES snapshots can be loaded from S3. This will be used to create an appropriate IAM role"
+variable "snapshot_s3_bucket" {
+  description = "The bucket where ES snapshots can be loaded from S3."
 }
 
 # General settings


### PR DESCRIPTION
This PR allows for an Elasticsearch snapshot to be loaded automatically as the cluster starts. Very convenient.