### PR TITLE
Allow setting ES fielddata circuit breaker limit

### DIFF
--- a/elasticsearch/terraform/cloud_init.tf
+++ b/elasticsearch/terraform/cloud_init.tf
@@ -12,6 +12,7 @@ data "template_file" "setup" {
     expected_nodes                    = "${var.elasticsearch_desired_instances}"
     minimum_master_nodes              = "${var.elasticsearch_desired_instances/2 + 1}"
     elasticsearch_heap_memory_percent = "${var.elasticsearch_heap_memory_percent}"
+    elasticsearch_fielddata_limit     = "${var.elasticsearch_fielddata_limit}"
   }
 }
 

--- a/elasticsearch/terraform/templates/setup.sh.tpl
+++ b/elasticsearch/terraform/templates/setup.sh.tpl
@@ -36,6 +36,9 @@ index.search.slowlog.threshold.fetch.warn: 5s
 
 ## index time slowlog settings
 index.indexing.slowlog.threshold.index.info: 10s
+
+## circuit breakers
+indices.breaker.fielddata.limit: ${elasticsearch_fielddata_limit}
 EOF
 
 # heap size

--- a/elasticsearch/terraform/variables.tf
+++ b/elasticsearch/terraform/variables.tf
@@ -98,6 +98,11 @@ variable "es_allowed_urls" {
   default     = ""
 }
 
+variable "elasticsearch_fielddata_limit" {
+  description = "fielddata circuit breaker limit"
+  default     = "30%"
+}
+
 ## snapshot loading settings
 variable "snapshot_s3_bucket" {
   description = "The bucket where ES snapshots can be loaded from S3."


### PR DESCRIPTION
It can be very useful to limit the amount of fielddata that can be loaded. Until we merge https://github.com/pelias/schema/pull/302/files, there can be quite a bit of memory used by fielddata, for no benefit.