### PR TITLE
elasticsearch: make cluster read only after loading snapshot

### DIFF
--- a/elasticsearch/terraform/templates/load_snapshot.sh.tpl
+++ b/elasticsearch/terraform/templates/load_snapshot.sh.tpl
@@ -101,4 +101,11 @@ curl -s -XPUT "$cluster_url/$snapshot_name/_settings" -d "{
     \"number_of_replicas\" : $replica_count
   }
 }"
+
+## 6. make cluster read_only (prevents deletion of indices)
+curl -s -XPUT "$cluster_url/_cluster/settings" -d '{
+  "persistent" : {
+    "cluster.blocks.read_only" : true
+  }
+}'
 echo


### PR DESCRIPTION
This helps prevent against any sort of accidental damage:
https://www.elastic.co/guide/en/elasticsearch/reference/2.4/misc-cluster.html#cluster-read-only

Example output:
```
ubuntu@ip-172-20-101-136:~$ curl -XDELETE http://localhost:9200/pelias
{"error":{"root_cause":[{"type":"cluster_block_exception","reason":"blocked by: [FORBIDDEN/6/cluster read-only (api)];"}],"type":"cluster_block_exception","reason":"blocked by: [FORBIDDEN/6/cluster read-only (api)];"},"status":403}
```

With a few more changes like this, we might even be able to make our Elasticsearch clusters @trescube -proof :grin: 