### PR TITLE
Add a canary API deployment option

### DIFF
--- a/templates/api-canary-deployment.tpl
+++ b/templates/api-canary-deployment.tpl
@@ -1,0 +1,43 @@
+{{- if .Values.api.canaryDockerTag }}
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: pelias-api-canary
+spec:
+  replicas: {{ .Values.api.canaryReplicas | default 1 }}
+  minReadySeconds: {{ .Values.api.minReadySeconds  | default 10 }}
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: {{ if .Values.api.privateCanary }} pelias-api-private-canary {{ else }} pelias-api {{ end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.tpl") . | sha256sum }}
+    spec:
+      containers:
+        - name: pelias-api
+          image: pelias/api:{{ .Values.api.canaryDockerTag | default "latest" }}
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/config
+          env:
+            - name: PELIAS_CONFIG
+              value: "/etc/config/pelias.json"
+          resources:
+            limits:
+              memory: 0.5Gi
+              cpu: 1.5
+            requests:
+              memory: {{ .Values.api.requests.memory | quote | default "0.5Gi" }}
+              cpu: {{ .Values.api.requests.cpu | quote | default "0.25" }}
+      volumes:
+        - name: config-volume
+          configMap:
+            name: pelias-json-configmap
+            items:
+              - key: pelias.json
+                path: pelias.json
+{{- end -}}

--- a/templates/api-deployment.tpl
+++ b/templates/api-deployment.tpl
@@ -30,8 +30,8 @@ spec:
               memory: 0.5Gi
               cpu: 1.5
             requests:
-              memory: 0.5Gi
-              cpu: 0.25
+              memory: {{ .Values.api.requests.memory | quote | default "0.5Gi" }}
+              cpu: {{ .Values.api.requests.cpu | quote | default "0.25" }}
       volumes:
         - name: config-volume
           configMap:

--- a/templates/api-deployment.tpl
+++ b/templates/api-deployment.tpl
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: pelias-api
 spec:
-  replicas: {{ .Values.apiReplicas | default 1 }}
+  replicas: {{ .Values.api.replicas | default 1 }}
   minReadySeconds: {{ .Values.api.minReadySeconds  | default 10 }}
   strategy:
     rollingUpdate:
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: pelias-api
-          image: pelias/api:{{ .Values.apiDockerTag | default "latest" }}
+          image: pelias/api:{{ .Values.api.dockerTag | default "latest" }}
           volumeMounts:
             - name: config-volume
               mountPath: /etc/config

--- a/templates/api-deployment.tpl
+++ b/templates/api-deployment.tpl
@@ -4,7 +4,7 @@ metadata:
   name: pelias-api
 spec:
   replicas: {{ .Values.apiReplicas | default 1 }}
-  minReadySeconds: 10 #kubernetes operates so fast it can be nice to slow things down a little
+  minReadySeconds: {{ .Values.api.minReadySeconds  | default 10 }}
   strategy:
     rollingUpdate:
       maxSurge: 1


### PR DESCRIPTION
This PR does some renaming of config properties to move all API configuration into its own subproperty. It can now be configured like this:

```
api:
  dockerTag: "someBranch"
  replicas:4 
  ...etc
```

Additionally, an `api.canaryDockerTag` configuration option is added. If present, this will set up a second deployment, which is configured with the same labels, and so will be connected to the `api-service` and receive traffic just like the standard API deployment. However, the docker tag and number of replicas can be configured independently. This allows testing code with only a fraction of all traffic.

Connects https://github.com/pelias/kubernetes/issues/50