### PR TITLE
feat(elasticsearch): Switch to launch_template

### DIFF
--- a/elasticsearch/terraform/elb.tf
+++ b/elasticsearch/terraform/elb.tf
@@ -6,6 +6,8 @@ resource "aws_elb" "elasticsearch_elb" {
   connection_draining       = true
   internal                  = true
 
+  tags = "${var.tags}"
+
   listener {
     instance_port     = 9200
     instance_protocol = "http"

--- a/elasticsearch/terraform/main.tf
+++ b/elasticsearch/terraform/main.tf
@@ -41,9 +41,12 @@ resource "aws_autoscaling_group" "elasticsearch" {
   desired_capacity     = "${var.elasticsearch_desired_instances}"
   default_cooldown     = 30
   force_delete         = true
+
   launch_template      = {
-    id = "${aws_launch_template.elasticsearch.id}"
+    id      = "${aws_launch_template.elasticsearch.id}"
+    version = "$$Latest"
   }
+
   vpc_zone_identifier  = ["${data.aws_subnet_ids.all_subnets.ids}"]
   load_balancers       = ["${aws_elb.elasticsearch_elb.id}"]
 

--- a/elasticsearch/terraform/main.tf
+++ b/elasticsearch/terraform/main.tf
@@ -27,6 +27,11 @@ resource "aws_launch_template" "elasticsearch" {
       volume_type = "gp2"
     }
   }]
+
+  tag_specifications {
+    resource_type = "instance"
+    tags = "${var.tags}"
+  }
 }
 
 resource "aws_autoscaling_group" "elasticsearch" {
@@ -51,6 +56,12 @@ resource "aws_autoscaling_group" "elasticsearch" {
   tag {
     key                 = "team"
     value               = "${var.service_name}"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key   = "env"
+    value = "${var.environment}"
     propagate_at_launch = true
   }
 

--- a/elasticsearch/terraform/main.tf
+++ b/elasticsearch/terraform/main.tf
@@ -1,36 +1,32 @@
-resource "aws_launch_configuration" "elasticsearch" {
+resource "aws_launch_template" "elasticsearch" {
   name_prefix                 = "${var.service_name}-${var.environment}-elasticsearch-"
   image_id                    = "${data.aws_ami.elasticsearch_ami.id}"
   instance_type               = "${var.elasticsearch_instance_type}"
-  security_groups             = ["${aws_security_group.elasticsearch.id}"]
-  associate_public_ip_address = false
+  vpc_security_group_ids      = ["${aws_security_group.elasticsearch.id}"]
 
-  # use EBS optimized instances unless launching at t2 instance
-  ebs_optimized        = "${format("%.1s", var.elasticsearch_instance_type) == "t" ? false : true}"
   key_name             = "${var.ssh_key_name}"
   user_data            = "${data.template_cloudinit_config.cloud_init.rendered}"
-  iam_instance_profile = "${aws_iam_instance_profile.elasticsearch.arn}"
+  iam_instance_profile = {
+    arn = "${aws_iam_instance_profile.elasticsearch.arn}"
+  }
 
   lifecycle {
     create_before_destroy = true
   }
 
-  root_block_device {
-    volume_size = "${var.elasticsearch_root_volume_size}"
-    volume_type = "gp2"
-  }
-
-  ebs_block_device = [{
+  block_device_mappings = [{
     device_name = "/dev/sdb"
-    volume_size = "${var.elasticsearch_data_volume_size}"
-    volume_type = "gp2"
-  },
-    {
-      device_name = "/dev/sdc"
+    ebs {
+      volume_size = "${var.elasticsearch_data_volume_size}"
+      volume_type = "gp2"
+    }
+  }, {
+    device_name = "/dev/sdc"
+    ebs {
       volume_size = "${var.elasticsearch_log_volume_size}"
       volume_type = "gp2"
-    },
-  ]
+    }
+  }]
 }
 
 resource "aws_autoscaling_group" "elasticsearch" {
@@ -40,7 +36,9 @@ resource "aws_autoscaling_group" "elasticsearch" {
   desired_capacity     = "${var.elasticsearch_desired_instances}"
   default_cooldown     = 30
   force_delete         = true
-  launch_configuration = "${aws_launch_configuration.elasticsearch.id}"
+  launch_template      = {
+    id = "${aws_launch_template.elasticsearch.id}"
+  }
   vpc_zone_identifier  = ["${data.aws_subnet_ids.all_subnets.ids}"]
   load_balancers       = ["${aws_elb.elasticsearch_elb.id}"]
 

--- a/elasticsearch/terraform/variables.tf
+++ b/elasticsearch/terraform/variables.tf
@@ -143,3 +143,8 @@ variable "environment" {
   description = "Which environment (dev, staging, prod, etc) this group of machines is for"
   default     = "dev"
 }
+
+variable "tags" {
+  description = "Custom tags to add to all resources"
+  default     = {}
+}


### PR DESCRIPTION
[AWS Launch Templates](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-launch-templates.html) are AWS's new feature to replace Launch Configurations, with some additional abilities.

They can be used both with an AutoScalingGroup, or with a single instance. In our case a nice additional benefit is it's easier to set tags on an instance.