### PR TITLE
feat(Elasticsearch): allow disabling ELB

### DIFF
--- a/elasticsearch/terraform/elb.tf
+++ b/elasticsearch/terraform/elb.tf
@@ -8,6 +8,8 @@ resource "aws_elb" "elasticsearch_elb" {
 
   tags = "${var.tags}"
 
+  count = "${var.elb}"
+
   listener {
     instance_port     = 9200
     instance_protocol = "http"

--- a/elasticsearch/terraform/main.tf
+++ b/elasticsearch/terraform/main.tf
@@ -48,7 +48,7 @@ resource "aws_autoscaling_group" "elasticsearch" {
   }
 
   vpc_zone_identifier  = ["${data.aws_subnet_ids.all_subnets.ids}"]
-  load_balancers       = ["${aws_elb.elasticsearch_elb.id}"]
+  load_balancers       = ["${aws_elb.elasticsearch_elb.*.id}"]
 
   tag {
     key                 = "Name"

--- a/elasticsearch/terraform/outputs.tf
+++ b/elasticsearch/terraform/outputs.tf
@@ -1,3 +1,3 @@
 output "aws_elb" {
-  value = "${aws_elb.elasticsearch_elb.dns_name}"
+  value = "${aws_elb.elasticsearch_elb.*.dns_name}"
 }

--- a/elasticsearch/terraform/variables.tf
+++ b/elasticsearch/terraform/variables.tf
@@ -148,3 +148,8 @@ variable "tags" {
   description = "Custom tags to add to all resources"
   default     = {}
 }
+
+variable "elb" {
+  description = "Whether or not to launch an ELB"
+  default     = true
+}


### PR DESCRIPTION
Sometimes, an ELB is unwanted when creating an ES cluster. It might be just for testing, or there might be a single instance and an ELB is not needed.

This allows disabling ELB creation by setting the `elb` variable to false.