### PR TITLE
Add autocomplete address_exclude setting

### DIFF
--- a/templates/configmap.tpl
+++ b/templates/configmap.tpl
@@ -25,6 +25,9 @@ data:
         }
       },
       "api": {
+        "autocomplete": {
+          "exclude_address_length": {{ .Values.api.autocomplete.exclude_address_length | default 0 }}
+        },
         "attributionURL": "{{ .Values.apiAttributionURL }}",
         "indexName": "{{ .Values.apiIndexName }}",
         "services": {

--- a/values.yaml
+++ b/values.yaml
@@ -10,6 +10,10 @@ externalAPIService: false
 # whether this ELB should be internet facing or private (default private)
 privateAPILoadBalancer: true
 
+## API settings
+api:
+  autocomplete: {}
+
 # the name of the Elasticsearch index to use
 apiIndexName: "pelias"
 apiAttributionURL: "http://api.yourpelias.com/attribution"


### PR DESCRIPTION
Now that https://github.com/pelias/api/pull/1219 is merged, we need to control this parameter in the `pelias.json` configmap.

I can see this starting to get unwieldy over time as we start building more and more config options in, but for now it's fine.