### PR TITLE
Add rollingUpdate settings to deployments

### DIFF
--- a/templates/interpolation-deployment.tpl
+++ b/templates/interpolation-deployment.tpl
@@ -4,6 +4,10 @@ metadata:
   name: pelias-interpolation
 spec:
   replicas: {{ .Values.interpolationReplicas | default 1 }}
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   template:
     metadata:
       labels:

--- a/templates/libpostal-deployment.tpl
+++ b/templates/libpostal-deployment.tpl
@@ -4,6 +4,10 @@ metadata:
   name: pelias-libpostal
 spec:
   replicas: {{ .Values.libpostalReplicas | default 1 }}
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   template:
     metadata:
       labels:

--- a/templates/placeholder-deployment.tpl
+++ b/templates/placeholder-deployment.tpl
@@ -5,6 +5,10 @@ metadata:
 spec:
   replicas: {{ .Values.placeholderReplicas | default 1 }}
   minReadySeconds: 30
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   template:
     metadata:
       labels:


### PR DESCRIPTION
Eventually these must be configurable, but for now at least setting `maxUnavailable: 0` is important