### PR TITLE
Libpostal service improvements

### DIFF
--- a/templates/libpostal-deployment.tpl
+++ b/templates/libpostal-deployment.tpl
@@ -23,3 +23,11 @@ spec:
             requests:
               memory: 2Gi
               cpu: 0.1
+          livenessProbe:
+            httpGet:
+              path: /parse?address=readiness
+              port: 4400
+          readinessProbe:
+            httpGet:
+              path: /parse?address=readiness
+              port: 4400

--- a/templates/libpostal-deployment.tpl
+++ b/templates/libpostal-deployment.tpl
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: pelias-libpostal
-          image: pelias/go-whosonfirst-libpostal:{{ .Values.libpostalDockerTag | default "latest" }}
+          image: pelias/libpostal-service:{{ .Values.libpostalDockerTag | default "latest" }}
           resources:
             limits:
               memory: 3Gi

--- a/templates/libpostal-service.tpl
+++ b/templates/libpostal-service.tpl
@@ -7,5 +7,5 @@ spec:
         app: pelias-libpostal
     ports:
         - protocol: TCP
-          port: 8080
+          port: 4400
     type: ClusterIP

--- a/values.yaml
+++ b/values.yaml
@@ -23,7 +23,7 @@ dashboardEnabled: false
 
 placeholderHost: "http://pelias-placeholder-service:3000/"
 interpolationHost: "http://pelias-interpolation-service:3000/"
-libpostalHost: "http://pelias-libpostal-service:8080/"
+libpostalHost: "http://pelias-libpostal-service:4400/"
 pipHost: "http://pelias-pip-service:3102/"
 
 libpostalEnabled: true


### PR DESCRIPTION
Use the standard port from our Docker setup, add liveness/readiness probes.

Most importantly, the new [pelias/libpostal-service](https://github.com/pelias/libpostal-service) container is used 