### PR TITLE
feat: Dashboard ingress

### DIFF
--- a/templates/dashboard-deployment.yaml
+++ b/templates/dashboard-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.dashboard.enabled }}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -33,3 +34,4 @@ spec:
             requests:
               memory: 0.2Gi
               cpu: 0.25
+{{- end -}}

--- a/templates/dashboard-ingress.tpl
+++ b/templates/dashboard-ingress.tpl
@@ -1,0 +1,22 @@
+{{- if (and .Values.dashboard.domain .Values.dashboard.enabled) }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: pelias-dashboard-ingress
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    kubernetes.io/tls-acme: "true"
+spec:
+  rules:
+  - host: {{ .Values.dashboard.domain }}
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: pelias-dashboard-service
+          servicePort: 3030
+  tls:
+  - secretName: pelias-dashboard-tls
+    hosts:
+      - {{ .Values.dashboard.domain }}
+{{- end -}}

--- a/templates/dashboard-service.yaml
+++ b/templates/dashboard-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.dashboard.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -9,3 +10,4 @@ spec:
         - protocol: TCP
           port: 3030
     type: ClusterIP
+{{- end -}}

--- a/values.yaml
+++ b/values.yaml
@@ -19,7 +19,9 @@ apiIndexName: "pelias"
 apiAttributionURL: "http://api.yourpelias.com/attribution"
 
 # Whether the dashboard should be set up
-dashboardEnabled: false
+dashboard:
+  enabled: true
+  domain: null # set this to enable an ingress
 
 placeholderHost: "http://pelias-placeholder-service:3000/"
 interpolationHost: "http://pelias-interpolation-service:3000/"


### PR DESCRIPTION
This adds the option to create an Ingress resource for the Pelias dashboard. By specifying `dahboard.domain`, the ingress will be created and set up properly. Super handy.