### PR TITLE
Add optional API ingress

### DIFF
--- a/templates/api-ingress.tpl
+++ b/templates/api-ingress.tpl
@@ -1,0 +1,22 @@
+{{- if .Values.api.domain }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: pelias-api-ingress
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    kubernetes.io/tls-acme: "true"
+spec:
+  rules:
+  - host: {{ .Values.api.domain }}
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: pelias-api-service
+          servicePort: 3100
+  tls:
+  - secretName: pelias-api-tls
+    hosts:
+      - {{ .Values.api.domain }}
+{{- end -}}


### PR DESCRIPTION
This makes it even easier to expose the Pelias API externally!

Set `.Values.api.domain` to the host you want to use, and an Ingress with proper HTTPS tags for kube-lego will be set up automatically.