### PR TITLE
fix(api-template): Fix validation of default requests

### DIFF
--- a/templates/api-canary-deployment.tpl
+++ b/templates/api-canary-deployment.tpl
@@ -31,8 +31,8 @@ spec:
               memory: 0.5Gi
               cpu: 1.5
             requests:
-              memory: {{ .Values.api.requests.memory | quote | default "0.25Gi" }}
-              cpu: {{ .Values.api.requests.cpu | quote | default "0.1" }}
+              memory: {{ .Values.api.requests.memory | default "0.25Gi" | quote }}
+              cpu: {{ .Values.api.requests.cpu | default "0.1" | quote }}
       volumes:
         - name: config-volume
           configMap:

--- a/templates/api-deployment.tpl
+++ b/templates/api-deployment.tpl
@@ -30,8 +30,8 @@ spec:
               memory: 0.5Gi
               cpu: 1.5
             requests:
-              memory: {{ .Values.api.requests.memory | quote | default "0.25Gi" }}
-              cpu: {{ .Values.api.requests.cpu | quote | default "0.1" }}
+              memory: {{ .Values.api.requests.memory | default "0.25Gi" | quote }}
+              cpu: {{ .Values.api.requests.cpu | default "0.1" | quote }}
       volumes:
         - name: config-volume
           configMap:


### PR DESCRIPTION
The `quote` directive has to come AFTER the default, or the default value will be ignored and an empty (but quoted) string will be used