### PR TITLE
modify configuration to support both elasticsearch versions 2.4 and 5.6

### DIFF
--- a/elasticsearch/packer/files/elastic_wait.sh
+++ b/elasticsearch/packer/files/elastic_wait.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -e
+
+# note: moved to shell script rather than being inline in a templatee file due to:
+# https://github.com/terraform-providers/terraform-provider-template/issues/51
+
+function elastic_status(){
+  curl \
+    --output /dev/null \
+    --silent \
+    --write-out "%{http_code}" \
+    "http://${ELASTIC_HOST:-localhost:9200}" || true;
+}
+
+function elastic_wait(){
+  echo 'waiting for elasticsearch service to come up';
+  retry_count=30
+
+  i=1
+  while [[ "$i" -le "$retry_count" ]]; do
+    if [[ $(elastic_status) -eq 200 ]]; then
+      echo
+      exit 0
+    fi
+    sleep 2
+    printf "."
+    i=$(($i + 1))
+  done
+
+  echo
+  echo "Elasticsearch did not come up, check configuration"
+  exit 1
+}

--- a/elasticsearch/packer/pelias-elasticsearch.json
+++ b/elasticsearch/packer/pelias-elasticsearch.json
@@ -1,6 +1,6 @@
 {
   "variables": {
-    "elasticsearch_version": "2.4.6",
+    "elasticsearch_version": "5.6.12",
     "aws_access_key": "",
     "aws_secret_key": "",
     "subnet_id": ""
@@ -40,6 +40,11 @@
       "type": "file",
       "source": "./files/aws-udev.rules",
       "destination": "/tmp/10-aws.rules"
+    },
+    {
+      "type": "file",
+      "source": "./files/elastic_wait.sh",
+      "destination": "/home/ubuntu/elastic_wait.sh"
     },
     {
       "type": "shell",

--- a/elasticsearch/packer/scripts/default.sh
+++ b/elasticsearch/packer/scripts/default.sh
@@ -9,6 +9,8 @@ sudo apt-get install htop dstat -y
 
 echo "elasticsearch soft nofile 128000
 elasticsearch hard nofile 128000
+elasticsearch soft memlock unlimited
+elasticsearch hard memlock unlimited
 root soft nofile 128000
 root hard nofile 128000" | sudo tee --append /etc/security/limits.conf
 

--- a/elasticsearch/terraform/templates/load_snapshot.sh.tpl
+++ b/elasticsearch/terraform/templates/load_snapshot.sh.tpl
@@ -23,16 +23,11 @@ if [[ "$s3_bucket" == "" ]]; then
   exit 0
 fi
 
-## 0. wait for elasticsearch to become ready
-function elastic_status(){
-  curl --output /dev/null --silent --write-out "%%{http_code}" "$cluster_url" || true;
-}
+# Import elastic status/wait scripts
+. /home/ubuntu/elastic_wait.sh
 
-echo "waiting for elasticsearch on $cluster_url"
-until test $(elastic_status) -eq 200; do
-  printf '.'
-  sleep 2
-done
+## 0. wait for elasticsearch to become ready
+(elastic_wait)
 
 # check if this node is the master node
 cluster_url="http://localhost:9200"

--- a/elasticsearch/terraform/templates/setup.sh.tpl
+++ b/elasticsearch/terraform/templates/setup.sh.tpl
@@ -80,36 +80,11 @@ fi
 # Start Elasticsearch
 sudo service elasticsearch start
 
-function elastic_status(){
-  curl \
-    --output /dev/null \
-    --silent \
-    --write-out "%{http_code}" \
-    "http://${ELASTIC_HOST:-localhost:9200}" || true;
-}
-
-function elastic_wait(){
-  echo 'waiting for elasticsearch service to come up';
-  retry_count=30
-
-  i=1
-  while [[ "$i" -le "$retry_count" ]]; do
-    if [[ $(elastic_status) -eq 200 ]]; then
-      echo
-      exit 0
-    fi
-    sleep 2
-    printf "."
-    i=$(($i + 1))
-  done
-
-  echo
-  echo "Elasticsearch did not come up, check configuration"
-  exit 1
-}
+# Import elastic status/wait scripts
+. /home/ubuntu/elastic_wait.sh
 
 # Wait for elasticsearch service to come up
-elastic_wait;
+elastic_wait
 
 # Put index template
 # These settings will be automatically merged when creating new indices.

--- a/elasticsearch/terraform/templates/setup.sh.tpl
+++ b/elasticsearch/terraform/templates/setup.sh.tpl
@@ -88,7 +88,7 @@ sudo service elasticsearch start
 # These settings will be automatically merged when creating new indices.
 # Since elasticsearch v5+ this is now the recommended way to set node-specific settings.
 # https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html
-$(elastic_wait) && curl \
+(elastic_wait) && curl \
   -X PUT \
   -H 'Content-Type: application/json' \
   -d '{

--- a/elasticsearch/terraform/templates/setup.sh.tpl
+++ b/elasticsearch/terraform/templates/setup.sh.tpl
@@ -35,7 +35,7 @@ EOF
 
 # elasticsearch 2.4 specific settings
 # note: we can check if 'bin/plugin' exists, this was renamed after 2.4
-if [ ! -f '/usr/share/elasticsearch/bin/plugin' ]; then
+if [ -f '/usr/share/elasticsearch/bin/plugin' ]; then
   # in older versions of ES 'memory_lock' is called 'mlockall'
   sed -i 's/bootstrap.memory_lock/bootstrap.mlockall/g' /etc/elasticsearch/elasticsearch.yml
 fi

--- a/elasticsearch/terraform/templates/setup.sh.tpl
+++ b/elasticsearch/terraform/templates/setup.sh.tpl
@@ -83,14 +83,12 @@ sudo service elasticsearch start
 # Import elastic status/wait scripts
 . /home/ubuntu/elastic_wait.sh
 
-# Wait for elasticsearch service to come up
-elastic_wait
-
+# Wait for elasticsearch service to come up (note elastic_wait exits 0|1); then
 # Put index template
 # These settings will be automatically merged when creating new indices.
 # Since elasticsearch v5+ this is now the recommended way to set node-specific settings.
 # https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html
-curl \
+$(elastic_wait) && curl \
   -X PUT \
   -H 'Content-Type: application/json' \
   -d '{


### PR DESCRIPTION
This WIP PR updates the elasticsearch configuration to work with both `2.4` and `5.6`.

When starting the previously packed AMI `ami-035f0df0234dc6d2d`, elasticsearch would fail to come up and it was difficult to discover and debug errors, I discovered that they were being logged to `/usr/local/var/log/elasticsearch/pelias-dev-es5-test-elasticsearch.log`.

The following settings had to be changed:
- `bootstrap.mlockall` was renamed `bootstrap.memory_lock` in 5.6 - I am detecting the version and using the appropriate variable name.
- memlock is more difficult to achieve using `systemd`, some settings have been added to facilitate this.
- a default config value changed and the regex had to be updated to match both `#MAX_LOCKED_MEMORY=unlimited` and `#MAX_LOCKED_MEMORY=`
- index-level settings are no longer allowed in `elasticsearch.yml` from 5.6, so any settings beginning with `index.` were removed
- the recommendation for these is now to use an 'index template', so I added functions to wait for ES to come up and then PUT a global index template which merges those settings with any newly generated indices, this could also be useful in the future.

Requires additional testing in `2.4` to ensure backwards compatibility is maintained and in `5.6` to ensure that this all works as expected.

Fixes https://github.com/pelias/kubernetes/issues/52
Connects https://github.com/pelias/pelias/issues/461