### PR TITLE
curl: increase verbosity and exit(1) on >=400 status codes

### DIFF
--- a/elasticsearch/terraform/templates/setup.sh.tpl
+++ b/elasticsearch/terraform/templates/setup.sh.tpl
@@ -90,6 +90,7 @@ sudo service elasticsearch start
 # https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates.html
 (elastic_wait) && curl \
   -X PUT \
+  --fail \
   -H 'Content-Type: application/json' \
   -d '{
     "template": ["pelias*"],


### PR DESCRIPTION
This PR aims to resolve the issue mentioned in #68.

I've added the `--fail` flag to all `curl` commands which means that it will `exit(1)` on any status code gte 400.
I'm assuming this is correct for everything and that we aren't relying on silencing these errors at some point.

I've also removed all `-s` flags from `curl` in order to show more verbose output.
I'm not 100% that this the correct thing to do?
I usually only use that in non-interactive shells to silence the download progress bar.

resolves https://github.com/pelias/kubernetes/issues/68