### PR TITLE
add image annotation to API deployment pods

### DIFF
--- a/templates/api-deployment.tpl
+++ b/templates/api-deployment.tpl
@@ -14,6 +14,7 @@ spec:
       labels:
         app: pelias-api
       annotations:
+        image: pelias/api:{{ .Values.api.dockerTag | default "latest" }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.tpl") . | sha256sum }}
     spec:
       containers:


### PR DESCRIPTION
This helps with A/B testing if using a canary