### PR TITLE
Add elasticsearch annotation to API deployments

### DIFF
--- a/templates/api-canary-deployment.tpl
+++ b/templates/api-canary-deployment.tpl
@@ -17,6 +17,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.tpl") . | sha256sum }}
         image: pelias/api:{{ .Values.api.dockerTag | default "latest" }}
+        elasticsearch: {{ .Values.elasticsearch.host }}
     spec:
       containers:
         - name: pelias-api

--- a/templates/api-deployment.tpl
+++ b/templates/api-deployment.tpl
@@ -16,6 +16,7 @@ spec:
       annotations:
         image: pelias/api:{{ .Values.api.dockerTag | default "latest" }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.tpl") . | sha256sum }}
+        elasticsearch: {{ .Values.elasticsearch.host }}
     spec:
       containers:
         - name: pelias-api


### PR DESCRIPTION
This is useful for quickly knowing which of what might be several recent clusters is in use for a given request