### PR TITLE
Helm config improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,30 @@ It can be useful to open a shell inside a running container for debugging:
 # kubectl exec -it {{pod_name}} -- {{command}}
 kubectl exec -it pelias-pip-3625698757-dtzmd -- /bin/bash
 ```
+
+# Helm Chart Configuration
+The following table lists common configurable parameters of the chart and
+their default values. See values.yaml for all available options.
+
+|       Parameter                        |           Description                       |                         Default                     |
+|----------------------------------------|---------------------------------------------|-----------------------------------------------------|
+| `elasticsearch.host`                   | Elasticsearch hostname                      | `elasticsearch-service`                                              |
+| `elasticsearch.port`                   | Elasticsearch access port                   | `9200`                                              |
+| `elasticsearch.protocol`               | Elasticsearch access protocol               | `http`                                              |
+| `elasticsearch.auth`                   | Elasticsearch authentication `user:pass`    | `-`                                              |
+| `pip.enabled`                          | Whether to enable pip service               | `true`                                              |
+| `pip.host`                             | Pip service url                             | `http://pelias-pip-service:3102/`                   |
+| `pip.pvc.create`                       | To use a custom PVC                         | `-`                                                 |
+| `pip.pvc.name`                         | Name of the PVC                             | `-`                                                 |
+| `pip.pvc.storageClass`                 | Storage Class to use for PVC	               | `-`                                                 |
+| `pip.pvc.storage`                      | Amount of space to claim for PVC	           | `-`                                                 |
+| `pip.pvc.annotations`                  | Storage Class annotation for PVC	           | `-`                                                 |
+| `pip.pvc.accessModes`                  | Access mode to use for PVC      	           | `-`                                                 |
+| `interpolation.enabled`                | Whether to enable interpolation service     | `false`                                             |
+| `interpolation.host`                   | Pip service url                             | `http://pelias-interpolation-service:3000/`           |
+| `interpolation.pvc.create`             | To use a custom PVC                         | `-`                                                 |
+| `interpolation.pvc.name`               | Name of the PVC                             | `-`                                                 |
+| `interpolation.pvc.storageClass`       | Storage Class to use for PVC	               | `-`                                                 |
+| `interpolation.pvc.storage`            | Amount of space to claim for PVC	           | `-`                                                 |
+| `interpolation.pvc.annotations`        | Storage Class annotation for PVC	           | `-`                                                 |
+| `interpolation.pvc.accessModes`        | Access mode to use for PVC      	           | `-`                                                 |

--- a/build/templates/geonames-import-job.tpl
+++ b/build/templates/geonames-import-job.tpl
@@ -14,7 +14,7 @@ spec:
           volumeMounts:
           - name: data-volume
             mountPath: /data
-        - name: geonames-download
+        - name: download
           image: pelias/geonames:{{ .Values.geonamesDockerTag | default "latest" }}
           command: ["./bin/download"]
           volumeMounts:

--- a/build/templates/geonames-import-job.tpl
+++ b/build/templates/geonames-import-job.tpl
@@ -16,7 +16,7 @@ spec:
             mountPath: /data
         - name: geonames-download
           image: pelias/geonames:{{ .Values.geonamesDockerTag | default "latest" }}
-          command: ["npm", "run", "download"]
+          command: ["./bin/download"]
           volumeMounts:
           - name: config-volume
             mountPath: /etc/config
@@ -35,7 +35,7 @@ spec:
       containers:
       - name: geonames-import-container
         image: pelias/geonames:{{ .Values.geonamesDockerTag | default "latest" }}
-        command: ["npm", "start"]
+        command: ["./bin/start"]
         volumeMounts:
           - name: config-volume
             mountPath: /etc/config

--- a/build/templates/openaddresses-import-job.tpl
+++ b/build/templates/openaddresses-import-job.tpl
@@ -14,7 +14,7 @@ spec:
         volumeMounts:
         - name: data-volume
           mountPath: /data
-      - name: openaddresses-download
+      - name: download
         image: pelias/openaddresses:{{ .Values.openaddressesDockerTag | default "latest" }}
         command: ["./bin/download"]
         volumeMounts:

--- a/build/templates/openaddresses-import-job.tpl
+++ b/build/templates/openaddresses-import-job.tpl
@@ -16,7 +16,7 @@ spec:
           mountPath: /data
       - name: openaddresses-download
         image: pelias/openaddresses:{{ .Values.openaddressesDockerTag | default "latest" }}
-        command: ["npm", "run", "download"]
+        command: ["./bin/download"]
         volumeMounts:
           - name: config-volume
             mountPath: /etc/config
@@ -35,7 +35,7 @@ spec:
       containers:
       - name: openaddresses-import-container
         image: pelias/openaddresses:{{ .Values.openaddressesDockerTag | default "latest" }}
-        command: ["npm", "run", "parallel", "2"]
+        command: ["./bin/start"]
         volumeMounts:
           - name: config-volume
             mountPath: /etc/config

--- a/build/templates/openstreetmap-import-job.tpl
+++ b/build/templates/openstreetmap-import-job.tpl
@@ -16,7 +16,7 @@ spec:
           mountPath: /data
       - name: openstreetmap-download
         image: pelias/openstreetmap:{{ .Values.openstreetmapDockerTag | default "latest"}}
-        command: ["npm", "run", "download"]
+        command: ["./bin/download"]
         volumeMounts:
           - name: config-volume
             mountPath: /etc/config
@@ -35,7 +35,7 @@ spec:
       containers:
       - name: openstreetmap-import-container
         image: pelias/openstreetmap:{{ .Values.openstreetmapDockerTag | default "latest"}}
-        command: ["npm", "start"]
+        command: ["./bin/start"]
         volumeMounts:
           - name: config-volume
             mountPath: /etc/config

--- a/build/templates/openstreetmap-import-job.tpl
+++ b/build/templates/openstreetmap-import-job.tpl
@@ -14,7 +14,7 @@ spec:
         volumeMounts:
         - name: data-volume
           mountPath: /data
-      - name: openstreetmap-download
+      - name: download
         image: pelias/openstreetmap:{{ .Values.openstreetmapDockerTag | default "latest"}}
         command: ["./bin/download"]
         volumeMounts:

--- a/build/templates/polylines-import-job.tpl
+++ b/build/templates/polylines-import-job.tpl
@@ -18,7 +18,7 @@ spec:
       containers:
       - name: polylines-import-container
         image: pelias/polylines:{{ .Values.polylinesDockerTag | default "latest" }}
-        command: ["npm", "start"]
+        command: ["./bin/start"]
         volumeMounts:
           - name: config-volume
             mountPath: /etc/config

--- a/build/templates/polylines-import-job.tpl
+++ b/build/templates/polylines-import-job.tpl
@@ -8,7 +8,7 @@ spec:
       name: polylines-import-pod
     spec:
       initContainers:
-        - name: polylines-download
+        - name: download
           image: busybox
           command: ["sh", "-c"]
           args: ["mkdir -p /data/polylines && wget -O- {{ .Values.polylinesDownloadURL }} | gunzip > /data/polylines/extract.0sv"]

--- a/build/templates/schema-create-job.tpl
+++ b/build/templates/schema-create-job.tpl
@@ -11,7 +11,7 @@ spec:
       initContainers:
       - name: schema-drop
         image: pelias/schema:{{ .Values.schemaDockerTag | default "latest" }}
-        command: ["npm", "run", "drop_index", "--", "-f", "||" , "true"]
+        command: ["node", "scripts/drop_index.js", "-f", "||" , "true"]
         volumeMounts:
           - name: config-volume
             mountPath: /etc/config
@@ -22,7 +22,7 @@ spec:
       containers:
       - name: schema-create
         image: pelias/schema:{{ .Values.schemaDockerTag | default "latest" }}
-        command: ["npm", "run", "create_index"]
+        command: ["./bin/create_index"]
         volumeMounts:
           - name: config-volume
             mountPath: /etc/config

--- a/build/templates/whosonfirst-import-job.tpl
+++ b/build/templates/whosonfirst-import-job.tpl
@@ -10,7 +10,7 @@ spec:
       initContainers:
       - name: wof-download
         image: pelias/whosonfirst:{{ .Values.whosonfirstDockerTag | default "latest" }}
-        command: ["npm", "run", "download"]
+        command: ["./bin/download"]
         volumeMounts:
           - name: config-volume
             mountPath: /etc/config
@@ -29,7 +29,7 @@ spec:
       containers:
       - name: whosonfirst-import-container
         image: pelias/whosonfirst:{{ .Values.whosonfirstDockerTag | default "latest" }}
-        command: ["npm", "start"]
+        command: ["./bin/start"]
         volumeMounts:
           - name: config-volume
             mountPath: /etc/config

--- a/build/templates/whosonfirst-import-job.tpl
+++ b/build/templates/whosonfirst-import-job.tpl
@@ -8,7 +8,7 @@ spec:
       name: whosonfirst-import
     spec:
       initContainers:
-      - name: wof-download
+      - name: download
         image: pelias/whosonfirst:{{ .Values.whosonfirstDockerTag | default "latest" }}
         command: ["./bin/download"]
         volumeMounts:

--- a/templates/api-canary-deployment.tpl
+++ b/templates/api-canary-deployment.tpl
@@ -4,8 +4,8 @@ kind: Deployment
 metadata:
   name: pelias-api-canary
 spec:
-  replicas: {{ .Values.api.canaryReplicas | default 1 }}
-  minReadySeconds: {{ .Values.api.minReadySeconds  | default 10 }}
+  replicas: {{ .Values.api.canaryReplicas }}
+  minReadySeconds: {{ .Values.api.minReadySeconds }}
   strategy:
     rollingUpdate:
       maxSurge: 1
@@ -16,12 +16,12 @@ spec:
         app: {{ if .Values.api.privateCanary }} pelias-api-private-canary {{ else }} pelias-api {{ end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.tpl") . | sha256sum }}
-        image: pelias/api:{{ .Values.api.dockerTag | default "latest" }}
+        image: pelias/api:{{ .Values.api.canaryDockerTag }}
         elasticsearch: {{ .Values.elasticsearch.host }}
     spec:
       containers:
         - name: pelias-api
-          image: pelias/api:{{ .Values.api.canaryDockerTag | default "latest" }}
+          image: pelias/api:{{ .Values.api.canaryDockerTag }}
           volumeMounts:
             - name: config-volume
               mountPath: /etc/config
@@ -33,8 +33,8 @@ spec:
               memory: 0.5Gi
               cpu: 1.5
             requests:
-              memory: {{ .Values.api.requests.memory | default "0.25Gi" | quote }}
-              cpu: {{ .Values.api.requests.cpu | default "0.1" | quote }}
+              memory: {{ .Values.api.requests.memory | quote }}
+              cpu: {{ .Values.api.requests.cpu | quote }}
       volumes:
         - name: config-volume
           configMap:

--- a/templates/api-deployment.tpl
+++ b/templates/api-deployment.tpl
@@ -3,8 +3,8 @@ kind: Deployment
 metadata:
   name: pelias-api
 spec:
-  replicas: {{ .Values.api.replicas | default 1 }}
-  minReadySeconds: {{ .Values.api.minReadySeconds  | default 10 }}
+  replicas: {{ .Values.api.replicas }}
+  minReadySeconds: {{ .Values.api.minReadySeconds  }}
   strategy:
     rollingUpdate:
       maxSurge: 1
@@ -14,13 +14,13 @@ spec:
       labels:
         app: pelias-api
       annotations:
-        image: pelias/api:{{ .Values.api.dockerTag | default "latest" }}
+        image: pelias/api:{{ .Values.api.dockerTag }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.tpl") . | sha256sum }}
         elasticsearch: {{ .Values.elasticsearch.host }}
     spec:
       containers:
         - name: pelias-api
-          image: pelias/api:{{ .Values.api.dockerTag | default "latest" }}
+          image: pelias/api:{{ .Values.api.dockerTag }}
           volumeMounts:
             - name: config-volume
               mountPath: /etc/config
@@ -32,8 +32,8 @@ spec:
               memory: 0.5Gi
               cpu: 1.5
             requests:
-              memory: {{ .Values.api.requests.memory | default "0.25Gi" | quote }}
-              cpu: {{ .Values.api.requests.cpu | default "0.1" | quote }}
+              memory: {{ .Values.api.requests.memory | quote }}
+              cpu: {{ .Values.api.requests.cpu | quote }}
       volumes:
         - name: config-volume
           configMap:

--- a/templates/api-deployment.tpl
+++ b/templates/api-deployment.tpl
@@ -17,6 +17,9 @@ spec:
         image: pelias/api:{{ .Values.api.dockerTag }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.tpl") . | sha256sum }}
         elasticsearch: {{ .Values.elasticsearch.host }}
+{{- if .Values.api.annotations }}
+{{ toYaml .Values.api.annotations | indent 8 }}
+{{- end }}
     spec:
       containers:
         - name: pelias-api

--- a/templates/configmap.tpl
+++ b/templates/configmap.tpl
@@ -102,7 +102,7 @@ data:
           "files": ["extract.0sv"]
         },
         "whosonfirst": {
-          "sqlite": {{ .Values.whosonfirst.sqlite | default false }},
+          "sqlite": {{ .Values.whosonfirst.sqlite }},
           {{ if .Values.whosonfirst.dataHost }}
           "dataHost": "{{ .Values.whosonfirst.dataHost}}",
           {{ end }}

--- a/templates/configmap.tpl
+++ b/templates/configmap.tpl
@@ -31,11 +31,11 @@ data:
         "attributionURL": "{{ .Values.apiAttributionURL | .Values.api.attributionURL }}",
         "indexName": "{{ .Values.apiIndexName | .Values.api.indexName }}",
         "services": {
-          {{ if .Values.placeholderEnabled  }}
+          {{ if .Values.placeholder.enabled  }}
           "placeholder": {
-            "url": "{{ .Values.placeholderHost }}",
-            "retries": {{ .Values.placeholderRetries | default 1 }},
-            "timeout": {{ .Values.placeholderTimeout | default 5000 }}
+            "url": "{{ .Values.placeholder.host }}",
+            "retries": {{ .Values.placeholder.retries }},
+            "timeout": {{ .Values.placeholder.timeout }}
           },
           {{- end }}
           {{- if .Values.interpolationEnabled | default .Values.interpolation.enabled }}

--- a/templates/configmap.tpl
+++ b/templates/configmap.tpl
@@ -26,10 +26,10 @@ data:
       },
       "api": {
         "autocomplete": {
-          "exclude_address_length": {{ .Values.api.autocomplete.exclude_address_length | default 0 }}
+          "exclude_address_length": {{ .Values.api.autocomplete.exclude_address_length }}
         },
-        "attributionURL": "{{ .Values.apiAttributionURL }}",
-        "indexName": "{{ .Values.apiIndexName }}",
+        "attributionURL": "{{ .Values.apiAttributionURL | .Values.api.attributionURL }}",
+        "indexName": "{{ .Values.apiIndexName | .Values.api.indexName }}",
         "services": {
           {{ if .Values.placeholderEnabled  }}
           "placeholder": {

--- a/templates/configmap.tpl
+++ b/templates/configmap.tpl
@@ -38,18 +38,18 @@ data:
             "timeout": {{ .Values.placeholder.timeout }}
           },
           {{- end }}
-          {{- if .Values.interpolationEnabled | default .Values.interpolation.enabled }}
+          {{- if .Values.interpolation.enabled }}
           "interpolation": {
-            "url": "{{ .Values.interpolationHost | default .Values.interpolation.host }}",
-            "retries": {{ .Values.interpolationRetries | default 1 }},
-            "timeout": {{ .Values.interpolationTimeout | default 5000 }}
+            "url": "{{ .Values.interpolation.host }}",
+            "retries": {{ .Values.interpolation.retries }},
+            "timeout": {{ .Values.interpolation.timeout }}
           },
           {{- end }}
-          {{- if .Values.pipEnabled | default .Values.pip.enabled }}
+          {{- if .Values.pip.enabled }}
           "pip": {
-            "url": "{{ .Values.pipHost | default .Values.pip.host}}",
-            "retries": {{ .Values.pipRetries | default 1 }},
-            "timeout": {{ .Values.pipTimeout | default 5000 }}
+            "url": "{{ .Values.pip.host }}",
+            "retries": {{ .Values.pip.retries }},
+            "timeout": {{ .Values.pip.timeout }}
           },
           {{- end }}
           "libpostal": {

--- a/templates/configmap.tpl
+++ b/templates/configmap.tpl
@@ -31,27 +31,27 @@ data:
         "attributionURL": "{{ .Values.apiAttributionURL }}",
         "indexName": "{{ .Values.apiIndexName }}",
         "services": {
-         {{ if .Values.placeholderEnabled  }}
+          {{ if .Values.placeholderEnabled  }}
           "placeholder": {
             "url": "{{ .Values.placeholderHost }}",
             "retries": {{ .Values.placeholderRetries | default 1 }},
             "timeout": {{ .Values.placeholderTimeout | default 5000 }}
           },
-         {{ end }}
-          {{ if .Values.interpolationEnabled }}
+          {{- end }}
+          {{- if .Values.interpolationEnabled | default .Values.interpolation.enabled }}
           "interpolation": {
-            "url": "{{ .Values.interpolationHost }}",
+            "url": "{{ .Values.interpolationHost | default .Values.interpolation.host }}",
             "retries": {{ .Values.interpolationRetries | default 1 }},
             "timeout": {{ .Values.interpolationTimeout | default 5000 }}
           },
-          {{ end }}
-          {{ if .Values.pipEnabled }}
+          {{- end }}
+          {{- if .Values.pipEnabled | default .Values.pip.enabled }}
           "pip": {
-            "url": "{{ .Values.pipHost }}",
+            "url": "{{ .Values.pipHost | default .Values.pip.host}}",
             "retries": {{ .Values.pipRetries | default 1 }},
             "timeout": {{ .Values.pipTimeout | default 5000 }}
           },
-          {{ end }}
+          {{- end }}
           "libpostal": {
             "url": "{{ .Values.libpostalHost }}",
             "retries": {{ .Values.libpostalRetries | default 1 }},

--- a/templates/configmap.tpl
+++ b/templates/configmap.tpl
@@ -53,9 +53,9 @@ data:
           },
           {{- end }}
           "libpostal": {
-            "url": "{{ .Values.libpostalHost }}",
-            "retries": {{ .Values.libpostalRetries | default 1 }},
-            "timeout": {{ .Values.libpostalTimeout | default 5000 }}
+            "url": "{{ .Values.libpostal.host }}",
+            "retries": {{ .Values.libpostal.retries }},
+            "timeout": {{ .Values.libpostal.timeout }}
           }
         }
       },

--- a/templates/dashboard-deployment.yaml
+++ b/templates/dashboard-deployment.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   name: pelias-dashboard
 spec:
-  replicas: {{ .Values.dashboardReplicas | default 1 }}
+  replicas: {{ .Values.dashboard.replicas }}
   minReadySeconds: 30 #kubernetes operates so fast it can be nice to slow things down a little
   strategy:
     rollingUpdate:
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: pelias-dashboard
-          image: pelias/dashboard:{{ .Values.dashboardDockerTag | default "latest" }}
+          image: pelias/dashboard:{{ .Values.dashboard.dockerTag }}
           env:
             - name: AUTH_TOKEN
               value: "foo"

--- a/templates/interpolation-deployment.tpl
+++ b/templates/interpolation-deployment.tpl
@@ -15,7 +15,7 @@ spec:
         app: pelias-interpolation
     spec:
       initContainers:
-        - name: interpolation-download
+        - name: download
           image: busybox
           command: [ "sh", "-c",
             "mkdir -p /data/interpolation/ &&\n

--- a/templates/interpolation-deployment.tpl
+++ b/templates/interpolation-deployment.tpl
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   name: pelias-interpolation
 spec:
-  replicas: {{ .Values.interpolationReplicas | default 1 }}
+  replicas: {{ .Values.interpolation.replicas }}
   strategy:
     rollingUpdate:
       maxSurge: 1
@@ -33,7 +33,7 @@ spec:
               cpu: 0.1
       containers:
         - name: pelias-interpolation
-          image: pelias/interpolation:{{ .Values.interpolationDockerTag | default "latest" }}
+          image: pelias/interpolation:{{ .Values.interpolation.dockerTag }}
           volumeMounts:
             - name: data-volume
               mountPath: /data

--- a/templates/interpolation-deployment.tpl
+++ b/templates/interpolation-deployment.tpl
@@ -1,3 +1,4 @@
+{{- if (or (.Values.interpolationEnabled) (.Values.interpolation.enabled))  }}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -45,4 +46,10 @@ spec:
               cpu: 0.1
       volumes:
         - name: data-volume
+        {{- if .Values.interpolation.pvc.create }}
+          persistentVolumeClaim:
+          claimName: {{ .Values.interpolation.pvc.name }}
+        {{- else }}
           emptyDir: {}
+        {{- end }}
+{{- end -}}

--- a/templates/interpolation-deployment.tpl
+++ b/templates/interpolation-deployment.tpl
@@ -17,10 +17,10 @@ spec:
       initContainers:
         - name: interpolation-download
           image: busybox
-          command: ["sh", "-c",
+          command: [ "sh", "-c",
             "mkdir -p /data/interpolation/ &&\n
-             wget -O- https://s3.amazonaws.com/pelias-data.nextzen.org/interpolation/current/street.db.gz | gunzip > /data/interpolation/street.db &\n
-             wget -O- https://s3.amazonaws.com/pelias-data.nextzen.org/interpolation/current/address.db.gz | gunzip > /data/interpolation/address.db" ]
+             wget -O - {{ .Values.interpolation.downloadPath }}/street.db.gz | gunzip > /data/interpolation/street.db &\n
+             wget -O - {{ .Values.interpolation.downloadPath }}/address.db.gz | gunzip > /data/interpolation/address.db" ]
           volumeMounts:
             - name: data-volume
               mountPath: /data

--- a/templates/interpolation-deployment.tpl
+++ b/templates/interpolation-deployment.tpl
@@ -13,6 +13,10 @@ spec:
     metadata:
       labels:
         app: pelias-interpolation
+      annotations:
+{{- if .Values.interpolation.annotations }}
+{{ toYaml .Values.interpolation.annotations | indent 8 }}
+{{- end }}
     spec:
       initContainers:
         - name: download

--- a/templates/interpolation-pvc.yaml
+++ b/templates/interpolation-pvc.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.interpolation.pvc.create }}
+{{- if (or (.Values.interpolationEnabled) (.Values.interpolation.enabled))  }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ .Values.interpolation.pvc.name }}
+  annotations:
+    {{- range $key, $value := .Values.interpolation.pvc.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  storageClassName: {{ .Values.interpolation.pvc.storageClass }}
+  accessModes:
+    - {{ .Values.interpolation.pvc.accessModes }}
+  resources:
+    requests:
+      storage: {{ .Values.interpolation.pvc.storage }}
+{{- end -}}
+{{- end -}}

--- a/templates/interpolation-service.tpl
+++ b/templates/interpolation-service.tpl
@@ -1,3 +1,4 @@
+{{- if (or (.Values.interpolationEnabled) (.Values.interpolation.enabled))  }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -9,3 +10,4 @@ spec:
         - protocol: TCP
           port: 3000
     type: ClusterIP
+{{- end -}}

--- a/templates/libpostal-deployment.tpl
+++ b/templates/libpostal-deployment.tpl
@@ -12,6 +12,10 @@ spec:
     metadata:
       labels:
         app: pelias-libpostal
+      annotations:
+{{- if .Values.libpostal.annotations }}
+{{ toYaml .Values.libpostal.annotations | indent 8 }}
+{{- end }}
     spec:
       containers:
         - name: pelias-libpostal

--- a/templates/libpostal-deployment.tpl
+++ b/templates/libpostal-deployment.tpl
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: pelias-libpostal
 spec:
-  replicas: {{ .Values.libpostalReplicas | default 1 }}
+  replicas: {{ .Values.libpostal.replicas }}
   strategy:
     rollingUpdate:
       maxSurge: 1
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: pelias-libpostal
-          image: pelias/libpostal-service:{{ .Values.libpostalDockerTag | default "latest" }}
+          image: pelias/libpostal-service:{{ .Values.libpostal.dockerTag }}
           resources:
             limits:
               memory: 3Gi

--- a/templates/pip-deployment.tpl
+++ b/templates/pip-deployment.tpl
@@ -4,12 +4,12 @@ kind: Deployment
 metadata:
   name: pelias-pip
 spec:
-  replicas: {{ .Values.pipReplicas | default 1 }}
+  replicas: {{ .Values.pip.replicas }}
   minReadySeconds: 60
   strategy:
     rollingUpdate:
       maxSurge: 1
-      maxUnavailable: {{ .Values.pipMaxUnavailable | default 0 }}
+      maxUnavailable: {{ .Values.pip.maxUnavailable }}
   template:
     metadata:
       labels:
@@ -17,7 +17,7 @@ spec:
     spec:
       initContainers:
         - name: wof-download
-          image: pelias/pip-service:{{ .Values.pipDockerTag | default "latest" }}
+          image: pelias/pip-service:{{ .Values.pip.dockerTag }}
           command: ["npm", "run", "download", "--", "--admin-only"]
           volumeMounts:
             - name: config-volume
@@ -36,7 +36,7 @@ spec:
               cpu: 0.1
       containers:
         - name: pelias-pip
-          image: pelias/pip-service:{{ .Values.pipDockerTag | default "latest" }}
+          image: pelias/pip-service:{{ .Values.pip.dockerTag }}
           volumeMounts:
             - name: config-volume
               mountPath: /etc/config

--- a/templates/pip-deployment.tpl
+++ b/templates/pip-deployment.tpl
@@ -18,7 +18,7 @@ spec:
       initContainers:
         - name: wof-download
           image: pelias/pip-service:{{ .Values.pip.dockerTag }}
-          command: ["npm", "run", "download", "--", "--admin-only"]
+          command: ["./bin/download", "--admin-only"]
           volumeMounts:
             - name: config-volume
               mountPath: /etc/config

--- a/templates/pip-deployment.tpl
+++ b/templates/pip-deployment.tpl
@@ -1,3 +1,4 @@
+{{- if (or (.Values.pipEnabled) (.Values.pip.enabled)) }}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -64,4 +65,10 @@ spec:
               - key: pelias.json
                 path: pelias.json
         - name: data-volume
+          {{- if .Values.pip.pvc.create }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.pip.pvc.name }}
+          {{- else }}
           emptyDir: {}
+          {{- end }}
+{{- end -}}

--- a/templates/pip-deployment.tpl
+++ b/templates/pip-deployment.tpl
@@ -16,7 +16,7 @@ spec:
         app: pelias-pip
     spec:
       initContainers:
-        - name: wof-download
+        - name: download
           image: pelias/pip-service:{{ .Values.pip.dockerTag }}
           command: ["./bin/download", "--admin-only"]
           volumeMounts:

--- a/templates/pip-deployment.tpl
+++ b/templates/pip-deployment.tpl
@@ -14,6 +14,10 @@ spec:
     metadata:
       labels:
         app: pelias-pip
+      annotations:
+{{- if .Values.pip.annotations }}
+{{ toYaml .Values.pip.annotations | indent 8 }}
+{{- end }}
     spec:
       initContainers:
         - name: download

--- a/templates/pip-pvc.yaml
+++ b/templates/pip-pvc.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.pip.pvc.create }}
+{{- if (or (.Values.pipEnabled) (.Values.pip.enabled)) }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ .Values.pip.pvc.name }}
+  annotations:
+    {{- range $key, $value := .Values.pip.pvc.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  storageClassName: {{ .Values.pip.pvc.storageClass }}
+  accessModes:
+    - {{ .Values.pip.pvc.accessModes }}
+  resources:
+    requests:
+      storage: {{ .Values.pip.pvc.storage }}
+{{- end -}}
+{{- end -}}

--- a/templates/pip-service.tpl
+++ b/templates/pip-service.tpl
@@ -1,3 +1,4 @@
+{{- if (or (.Values.pipEnabled) (.Values.pip.enabled)) }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -9,3 +10,4 @@ spec:
         - protocol: TCP
           port: 3102
     type: ClusterIP
+{{- end -}}

--- a/templates/placeholder-deployment.tpl
+++ b/templates/placeholder-deployment.tpl
@@ -40,7 +40,7 @@ spec:
             - name: PLACEHOLDER_DATA
               value: "/data/placeholder/"
             - name: CPUS
-              value: "1"
+              value: "{{ .Values.placeholder.cpus }}"
           resources:
             limits:
               memory: 1Gi

--- a/templates/placeholder-deployment.tpl
+++ b/templates/placeholder-deployment.tpl
@@ -13,6 +13,10 @@ spec:
     metadata:
       labels:
         app: pelias-placeholder
+      annotations:
+{{- if .Values.placeholder.annotations }}
+{{ toYaml .Values.placeholder.annotations | indent 8 }}
+{{- end }}
     spec:
       initContainers:
         - name: download

--- a/templates/placeholder-deployment.tpl
+++ b/templates/placeholder-deployment.tpl
@@ -15,7 +15,7 @@ spec:
         app: pelias-placeholder
     spec:
       initContainers:
-        - name: placeholder-download
+        - name: download
           image: busybox
           command: ["sh", "-c",
             "mkdir -p /data/placeholder/ &&\n

--- a/templates/placeholder-deployment.tpl
+++ b/templates/placeholder-deployment.tpl
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: pelias-placeholder
 spec:
-  replicas: {{ .Values.placeholderReplicas | default 1 }}
+  replicas: {{ .Values.placeholder.replicas }}
   minReadySeconds: 30
   strategy:
     rollingUpdate:
@@ -19,7 +19,7 @@ spec:
           image: busybox
           command: ["sh", "-c",
             "mkdir -p /data/placeholder/ &&\n
-             wget -O- {{ .Values.placeholderStoreURL }} | gunzip > /data/placeholder/store.sqlite3" ]
+             wget -O- {{ .Values.placeholder.storeURL }} | gunzip > /data/placeholder/store.sqlite3" ]
           volumeMounts:
             - name: data-volume
               mountPath: /data
@@ -32,7 +32,7 @@ spec:
               cpu: 0.2
       containers:
         - name: pelias-placeholder
-          image: pelias/placeholder:{{ .Values.placeholderDockerTag | default "latest" }}
+          image: pelias/placeholder:{{ .Values.placeholder.dockerTag }}
           volumeMounts:
             - name: data-volume
               mountPath: /data

--- a/values.yaml
+++ b/values.yaml
@@ -51,6 +51,8 @@ interpolation:
   replicas: 1
   host: "http://pelias-interpolation-service:3000/"
   dockerTag: "latest"
+  # URL prefix of location where streets.db and address.db will be downloaded
+  downloadPath: " https://s3.amazonaws.com/pelias-data.nextzen.org/interpolation/current"
   retries: 1 # number of time the API will retry requests to interpolation service
   timeout: 5000 # time in ms the API will wait for interpolation service responses
   pvc: {}

--- a/values.yaml
+++ b/values.yaml
@@ -45,11 +45,6 @@ libpostal:
   timeout: 5000 # time in ms the API will wait for libpostal responses
   annotations: {}
 
-# Whether the dashboard should be set up
-dashboard:
-  enabled: true
-  domain: null # set this to enable an ingress
-
 interpolation:
   enabled: false
   replicas: 1
@@ -85,6 +80,11 @@ pip:
 #    storage: 10Gi
 #    annotations: {}
 
+dashboard:
+  enabled: true
+  replicas: 1
+  dockerTag: "latest"
+  domain: null # set this to enable an ingress
 
 # Deprecated fields
 # pipEnabled: true

--- a/values.yaml
+++ b/values.yaml
@@ -30,17 +30,21 @@ placeholder:
   host: "http://pelias-placeholder-service:3000/"
   dockerTag: "latest"
   storeURL: "https://s3.amazonaws.com/pelias-data.nextzen.org/placeholder/store.sqlite3.gz"
-  retries: 1 # number of time the API will retry requests
+  retries: 1 # number of time the API will retry requests to placeholder
   timeout: 5000 # time in ms the API will wait for placeholder responses
+
+libpostal:
+  enabled: true
+  replicas: 1
+  host: "http://pelias-libpostal-service:4400/"
+  dockerTag: "latest"
+  retries: 1 # number of time the API will retry requests to libpostal
+  timeout: 5000 # time in ms the API will wait for libpostal responses
 
 # Whether the dashboard should be set up
 dashboard:
   enabled: true
   domain: null # set this to enable an ingress
-
-libpostalHost: "http://pelias-libpostal-service:4400/"
-
-libpostalEnabled: true
 
 interpolation:
   enabled: false

--- a/values.yaml
+++ b/values.yaml
@@ -23,6 +23,7 @@ api:
     memory: 0.25Gi
     cpu: 0.1
   minReadySeconds: 10
+  annotations: {}
 
 placeholder:
   enabled: true
@@ -33,6 +34,7 @@ placeholder:
   cpus: 1 # how many CPUs to allow using via the npm `cluster2` module
   retries: 1 # number of time the API will retry requests to placeholder
   timeout: 5000 # time in ms the API will wait for placeholder responses
+  annotations: {}
 
 libpostal:
   enabled: true
@@ -41,6 +43,7 @@ libpostal:
   dockerTag: "latest"
   retries: 1 # number of time the API will retry requests to libpostal
   timeout: 5000 # time in ms the API will wait for libpostal responses
+  annotations: {}
 
 # Whether the dashboard should be set up
 dashboard:
@@ -56,6 +59,7 @@ interpolation:
   downloadPath: " https://s3.amazonaws.com/pelias-data.nextzen.org/interpolation/current"
   retries: 1 # number of time the API will retry requests to interpolation service
   timeout: 5000 # time in ms the API will wait for interpolation service responses
+  annotations: {}
   pvc: {}
 #    create: true
 #    name: interpolation-pvc
@@ -72,6 +76,7 @@ pip:
   maxUnavailable: 0 # adjusts rolling update settings
   retries: 1 # number of time the API will retry requests to the pip service
   timeout: 5000 # time in ms the API will wait for pip service responses
+  annotations: {}
   pvc: {}
 #    create: true
 #    name: pip-pvc

--- a/values.yaml
+++ b/values.yaml
@@ -30,6 +30,7 @@ placeholder:
   host: "http://pelias-placeholder-service:3000/"
   dockerTag: "latest"
   storeURL: "https://s3.amazonaws.com/pelias-data.nextzen.org/placeholder/store.sqlite3.gz"
+  cpus: 1 # how many CPUs to allow using via the npm `cluster2` module
   retries: 1 # number of time the API will retry requests to placeholder
   timeout: 5000 # time in ms the API will wait for placeholder responses
 

--- a/values.yaml
+++ b/values.yaml
@@ -4,20 +4,25 @@ elasticsearch:
   port: 9200
   protocol: "http"
 
-# Whether the API service should be externally accessible
-# Set this to true if you want to, for example on AWS, set up an ELB for the API
-externalAPIService: false
-# whether this ELB should be internet facing or private (default private)
-privateAPILoadBalancer: true
-
 ## API settings
 api:
-  autocomplete: {}
-  requests: {}
-
-# the name of the Elasticsearch index to use
-apiIndexName: "pelias"
-apiAttributionURL: "http://api.yourpelias.com/attribution"
+  replicas: 1
+  canaryReplicas: 0
+  dockerTag: "latest"
+  canaryDockerTag: null # set this value to enable the canary deployment
+  indexName: "pelias"
+  attributionURL: "http://api.yourpelias.com/attribution"
+  # Whether the API service should be externally accessible
+  # Set this to true if you want to, for example on AWS, set up an ELB for the API
+  externalService: false
+  # whether the external service  should be internet facing or private (default private)
+  privateLoadBalancer: true
+  autocomplete:
+    exclude_address_length: 0
+  requests:
+    memory: 0.25Gi
+    cpu: 0.1
+  minReadySeconds: 10
 
 # Whether the dashboard should be set up
 dashboard:

--- a/values.yaml
+++ b/values.yaml
@@ -24,18 +24,23 @@ api:
     cpu: 0.1
   minReadySeconds: 10
 
+placeholder:
+  enabled: true
+  replicas: 1
+  host: "http://pelias-placeholder-service:3000/"
+  dockerTag: "latest"
+  storeURL: "https://s3.amazonaws.com/pelias-data.nextzen.org/placeholder/store.sqlite3.gz"
+  retries: 1 # number of time the API will retry requests
+  timeout: 5000 # time in ms the API will wait for placeholder responses
+
 # Whether the dashboard should be set up
 dashboard:
   enabled: true
   domain: null # set this to enable an ingress
 
-placeholderHost: "http://pelias-placeholder-service:3000/"
 libpostalHost: "http://pelias-libpostal-service:4400/"
 
 libpostalEnabled: true
-placeholderEnabled: true
-
-placeholderStoreURL: "https://s3.amazonaws.com/pelias-data.nextzen.org/placeholder/store.sqlite3.gz"
 
 interpolation:
   enabled: false

--- a/values.yaml
+++ b/values.yaml
@@ -48,7 +48,11 @@ dashboard:
 
 interpolation:
   enabled: false
+  replicas: 1
   host: "http://pelias-interpolation-service:3000/"
+  dockerTag: "latest"
+  retries: 1 # number of time the API will retry requests to interpolation service
+  timeout: 5000 # time in ms the API will wait for interpolation service responses
   pvc: {}
 #    create: true
 #    name: interpolation-pvc
@@ -59,7 +63,12 @@ interpolation:
 
 pip:
   enabled: true
+  replicas: 1
   host: "http://pelias-pip-service:3102/"
+  dockerTag: "latest"
+  maxUnavailable: 0 # adjusts rolling update settings
+  retries: 1 # number of time the API will retry requests to the pip service
+  timeout: 5000 # time in ms the API will wait for pip service responses
   pvc: {}
 #    create: true
 #    name: pip-pvc

--- a/values.yaml
+++ b/values.yaml
@@ -25,13 +25,39 @@ dashboard:
   domain: null # set this to enable an ingress
 
 placeholderHost: "http://pelias-placeholder-service:3000/"
-interpolationHost: "http://pelias-interpolation-service:3000/"
 libpostalHost: "http://pelias-libpostal-service:4400/"
-pipHost: "http://pelias-pip-service:3102/"
 
 libpostalEnabled: true
 placeholderEnabled: true
-pipEnabled: true
-interpolationEnabled: false
 
 placeholderStoreURL: "https://s3.amazonaws.com/pelias-data.nextzen.org/placeholder/store.sqlite3.gz"
+
+interpolation:
+  enabled: false
+  host: "http://pelias-interpolation-service:3000/"
+  pvc: {}
+#    create: true
+#    name: interpolation-pvc
+#    storageClass: aws-efs
+#    accessModes: ReadWriteMany
+#    storage: 10Gi
+#    annotations: {}
+
+pip:
+  enabled: true
+  host: "http://pelias-pip-service:3102/"
+  pvc: {}
+#    create: true
+#    name: pip-pvc
+#    storageClass: aws-efs
+#    accessModes: ReadWriteMany
+#    storage: 10Gi
+#    annotations: {}
+
+
+# Deprecated fields
+# pipEnabled: true
+# pipHost: "http://pelias-pip-service:3102/"
+
+# interpolationEnabled: false
+# interpolationHost: "http://pelias-interpolation-service:3000/"

--- a/values.yaml
+++ b/values.yaml
@@ -87,3 +87,8 @@ pip:
 
 # interpolationEnabled: false
 # interpolationHost: "http://pelias-interpolation-service:3000/"
+
+# Importer settings
+whosonfirst:
+  sqlite: false
+  dataHost: null


### PR DESCRIPTION
This adds many new configuration values and generally improves our Helm configuration.

- All config values are moved to nested yaml structures, so for example whereas there would previously be config values like `apiReplicas`, `apiDockerTag`, etc, they are now found as `api.replicas`, `api.dockerTag`, and similar. This leads to a much cleaner looking configuration where all services are nicely separated.
- All default config values are now in `values.yaml`, which makes that file a great source of documentation. Previously the defaults were strewn throughout the template files using the `default` function which [Helm recommends you only use for values that have to be computed](https://helm.sh/docs/chart_template_guide/#using-the-default-function)
- Lots more can be configured: the interpolation download location, placeholder clustering settings, ect
- All calls to NPM are removed (fixes #51)
- All Pelias services can now have arbitrary annotations added to each pod (see https://github.com/pelias/kubernetes/commit/0238531391c194eb89adc270e86203167a2c98c8 for details and use cases)
- All download containers are named `download` instead of `wof-download`, `interpolation-download`, `openstreetmap-download`, etc. This made it much harder to go from tailing logs of one pod to another, since you had to change the container name each time in commands such as `kubectl logs pod/pelias-whosonfirst-xxxx-yyy -c wof-download`

This PR includes and builds upon #44. Thanks @WeiBanjo for the original PR and sorry I didn't merge it sooner :)

Note that this PR didn't make any attempt to avoid breaking configuration changes. For anyone upgrading, you'll want to carefully review any custom settings you have and translate them over.
