### PR TITLE
feat(api): Allow configuring accessLog setting

### DIFF
--- a/templates/configmap.tpl
+++ b/templates/configmap.tpl
@@ -25,6 +25,7 @@ data:
         }
       },
       "api": {
+        "accessLog": "{{ .Values.api.accessLog }}",
         "autocomplete": {
           "exclude_address_length": {{ .Values.api.autocomplete.exclude_address_length }}
         },

--- a/values.yaml
+++ b/values.yaml
@@ -17,6 +17,7 @@ api:
   externalService: false
   # whether the external service  should be internet facing or private (default private)
   privateLoadBalancer: true
+  accessLog: "common" # allows configuring access log format. Empty string disables access log
   autocomplete:
     exclude_address_length: 0
   requests:


### PR DESCRIPTION
Combined with https://github.com/pelias/api/pull/1265, this PR allows configuring or disabling API access logging.

Connects #50 