### PR TITLE
fix #76: got rid of "attributionURL is not a method but has arguments"

### DIFF
--- a/templates/configmap.tpl
+++ b/templates/configmap.tpl
@@ -29,8 +29,8 @@ data:
         "autocomplete": {
           "exclude_address_length": {{ .Values.api.autocomplete.exclude_address_length }}
         },
-        "attributionURL": "{{ .Values.apiAttributionURL | .Values.api.attributionURL }}",
-        "indexName": "{{ .Values.apiIndexName | .Values.api.indexName }}",
+        "attributionURL": "{{ .Values.api.attributionURL }}",
+        "indexName": "{{ .Values.api.indexName }}",
         "services": {
           {{ if .Values.placeholder.enabled  }}
           "placeholder": {


### PR DESCRIPTION
This fix allows me to run `helm install --name pelias --namespace pelias . -f values.yaml` without
errors on helm v2.13.1.