### PR TITLE
feat(elasticsearch): Support disk watermark settings

### DIFF
--- a/elasticsearch/terraform/cloud_init.tf
+++ b/elasticsearch/terraform/cloud_init.tf
@@ -26,6 +26,8 @@ data "template_file" "load_snapshot" {
     snapshot_replica_count = "${var.snapshot_replica_count}"
     snapshot_alias_name = "${var.snapshot_alias_name}"
     snapshot_repository_read_only = "${var.snapshot_repository_read_only}"
+    high_disk_watermark               = "${var.elasticsearch_high_disk_watermark}"
+    low_disk_watermark               = "${var.elasticsearch_low_disk_watermark}"
   }
 }
 

--- a/elasticsearch/terraform/templates/load_snapshot.sh.tpl
+++ b/elasticsearch/terraform/templates/load_snapshot.sh.tpl
@@ -50,6 +50,24 @@ curl -s -XPUT --fail "$cluster_url/_cluster/settings" -d '{
 }'
 echo
 
+if [[ "${high_disk_watermark}" != "" ]]; then
+  echo "setting high disk watermark to ${high_disk_watermark}"
+  curl -s -XPUT --fail "$cluster_url/_cluster/settings" -d "{
+    \"persistent\": {
+      \"cluster.routing.allocation.disk.watermark.high\": \"${high_disk_watermark}\"
+    }
+  }"
+fi
+
+if [[ "${low_disk_watermark}" != "" ]]; then
+  echo "setting low disk watermark to ${low_disk_watermark}"
+  curl -s -XPUT --fail "$cluster_url/_cluster/settings" -d "{
+    \"persistent\": {
+      \"cluster.routing.allocation.disk.watermark.low\": \"${low_disk_watermark}\"
+    }
+  }"
+fi
+
 ## 2. create snapshot repository
 curl -s -XPOST --fail "$cluster_url/_snapshot/$es_repo_name" -d "{
   \"type\": \"s3\",

--- a/elasticsearch/terraform/variables.tf
+++ b/elasticsearch/terraform/variables.tf
@@ -103,6 +103,18 @@ variable "elasticsearch_fielddata_limit" {
   default     = "30%"
 }
 
+# disk based shard allocation filtering settings
+# https://www.elastic.co/guide/en/elasticsearch/reference/current/disk-allocator.html
+variable "elasticsearch_high_disk_watermark" {
+  description = "Elasticsearch high disk watermark setting"
+  default = ""
+}
+
+variable "elasticsearch_low_disk_watermark" {
+  description = "Elasticsearch low disk watermark setting"
+  default = ""
+}
+
 ## snapshot loading settings
 variable "snapshot_s3_bucket" {
   description = "The bucket where ES snapshots can be loaded from S3."


### PR DESCRIPTION
These settings configure how much available disk Elasticsearch will
allow itself to use before taking preventative action such as:
- preventing new replica shards from loading on a given node
- making the cluster read only

For Elasticsearch clusters where there is data being written and index
sizes are constantly in flux, it makes sense to have high safety margins
of free disk space.

On the other hand, for clusters initialized from a snapshot that won't
ever change, it's most efficient to allow using all available disk
space.

These settings allow tuning the cluster to fit any usecase along that
spectrum.

See https://www.elastic.co/guide/en/elasticsearch/reference/current/disk-allocator.html