### PR TITLE
feat(packer): Use OpenJDK instead of Oracle

### DIFF
--- a/elasticsearch/packer/scripts/java.sh
+++ b/elasticsearch/packer/scripts/java.sh
@@ -2,9 +2,4 @@
 
 export DEBIAN_FRONTEND=noninteractive
 
-sudo apt-get install -y python-software-properties debconf-utils
-sudo add-apt-repository -y ppa:webupd8team/java
-sudo apt-get update
-echo "oracle-java8-installer shared/accepted-oracle-license-v1-1 select true" | sudo debconf-set-selections
-
-sudo apt-get install -y oracle-java8-installer
+sudo apt-get install openjdk-8-jre -y


### PR DESCRIPTION
Oracle recently stopped offering free updates for their 1.8 series JDK. As a result, its not possible to install the version we've been using easily on Ubuntu.

The best free alternative now appears to be OpenJDK.

OpenJDK is not _technically_ the recommended version for Elasticsearch 5, however things will probably be ok. Going forward Elasticsearch 6 formally supports OpenJDK and Elasticsearch 7 actually bundles it, which will make things simpler.

References
 - https://www.azul.com/eliminating-java-update-confusion/
 - http://www.webupd8.org/2014/03/how-to-install-oracle-java-8-in-debian.html
 - https://www.elastic.co/support/matrix#matrix_jvm