### PR TITLE
Fix for data source build job

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,11 @@ helm install --name pelias-build --namespace pelias ./path/to/pelias/build/chart
 
 `values.yaml` can be reused between the two charts, however, the Pelias services chart must be up and running first.
 
-Build chart provides tamplates to build full planet from [data sources](https://mapzen.com/documentation/search/data-sources/). Before any of data source job is started make sure that below jobs are completed:
+Build chart provides tamplates to build full planet from [data sources](https://mapzen.com/documentation/search/data-sources/). Before any of data source job is started below jobs must be completed:
 - schema-create-job  - Creates Pelias index in Elasticsearch (Elasticsearch details are provided by configmap template in Pelias chart)
-- efs-presistent-volume and efs-pvc  - Creates PV/PVC in pelias namespace in k8s. It's used to download data by data source importers before data is loaded into Elasticsearch
+- efs-presistent-volume and efs-pvc  - Creates PV/PVC in pelias namespace in k8s. It's used to store downloaded data by data source importers before data is loaded into Elasticsearch
 
-To build smaller piece instead of full planet i.e. single country modification of configmap.tpl in Pelias chart is required. For download links and country codes see documentation of each individual [data sources](https://mapzen.com/documentation/search/data-sources/).
+To build a smaller piece instead of full planet i.e. single country modification of configmap.tpl in Pelias chart is required. For download links and country codes see documentation of each individual [data sources](https://mapzen.com/documentation/search/data-sources/).
 
 ## Elasticsearch
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ helm install --name pelias-build --namespace pelias ./path/to/pelias/build/chart
 
 `values.yaml` can be reused between the two charts, however, the Pelias services chart must be up and running first.
 
+Build chart provides tamplates to build full planet from [data sources](https://mapzen.com/documentation/search/data-sources/). Before any of data source job is started make sure that below jobs are completed:
+- schema-create-job  - Creates Pelias index in Elasticsearch (Elasticsearch details are provided by configmap template in Pelias chart)
+- efs-presistent-volume and efs-pvc  - Creates PV/PVC in pelias namespace in k8s. It's used to download data by data source importers before data is loaded into Elasticsearch
+
+To build smaller piece instead of full planet i.e. single country modification of configmap.tpl in Pelias chart is required. For download links and country codes see documentation of each individual [data sources](https://mapzen.com/documentation/search/data-sources/).
+
 ## Elasticsearch
 
 Elasticsearch is used as the primary datastore for Pelias data. As a powerful database with built in
@@ -80,6 +86,8 @@ hardware. To help with this, the `elasticsearch/` directory in this repository c
 setting up a production ready, Pelias compatible Elasticsearch cluster. It uses
 [Terraform](http://terraform.io/) and [Packer](http://packer.io/) to do this. See the directory
 [README](./elasticsearch/README.md) for more details.
+
+If you decided to lanuch Elasticsearch on AWS via AWS Console instead of provided Terraform/Packer solution you should change default port and protocol in values.yaml as AWS use https and 443 by default. 
 
 ## Handy Kubernetes commands
 

--- a/build/templates/geonames-import-job.tpl
+++ b/build/templates/geonames-import-job.tpl
@@ -10,7 +10,8 @@ spec:
       initContainers:
         - name: setup
           image: busybox
-          command: ["mkdir", "-p", "/data/geonames"]
+          command: ["/bin/sh","-c"]
+          args: ["mkdir -p /data/geonames && chown 1000:1000 /data/geonames"]
           volumeMounts:
           - name: data-volume
             mountPath: /data

--- a/build/templates/openaddresses-import-job.tpl
+++ b/build/templates/openaddresses-import-job.tpl
@@ -10,7 +10,8 @@ spec:
       initContainers:
       - name: setup
         image: busybox
-        command: ["mkdir", "-p", "/data/openaddresses"]
+        command: ["/bin/sh","-c"]
+        args: ["mkdir -p /data/openaddresses && chown 1000:1000 /data/openaddresses"]
         volumeMounts:
         - name: data-volume
           mountPath: /data

--- a/build/templates/openstreetmap-import-job.tpl
+++ b/build/templates/openstreetmap-import-job.tpl
@@ -10,7 +10,8 @@ spec:
       initContainers:
       - name: setup
         image: busybox
-        command: ["mkdir", "-p", "/data/openstreetmap"]
+        command: ["/bin/sh","-c"]
+        args: ["mkdir -p /data/openstreetmap && chown 1000:1000 /data/openstreetmap"]
         volumeMounts:
         - name: data-volume
           mountPath: /data

--- a/build/templates/whosonfirst-import-job.tpl
+++ b/build/templates/whosonfirst-import-job.tpl
@@ -8,6 +8,13 @@ spec:
       name: whosonfirst-import
     spec:
       initContainers:
+      - name: setup
+        image: busybox
+        command: ["/bin/sh","-c"]
+        args: ["mkdir -p /data/whosonfirst && chown 1000:1000 /data/whosonfirst"]
+        volumeMounts:
+          - name: data-volume
+            mountPath: /data
       - name: download
         image: pelias/whosonfirst:{{ .Values.whosonfirstDockerTag | default "latest" }}
         command: ["./bin/download"]
@@ -54,4 +61,5 @@ spec:
               - key: pelias.json
                 path: pelias.json
         - name: data-volume
-          emptyDir: {}
+          persistentVolumeClaim:
+            claimName: pelias-build-pvc

--- a/templates/api-service.tpl
+++ b/templates/api-service.tpl
@@ -3,11 +3,11 @@ kind: Service
 metadata:
     name: pelias-api-service
     annotations:
-      {{ if .Values.privateAPILoadBalancer }}service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0{{ end }}
+      {{ if .Values.api.privateLoadBalancer }}service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0{{ end }}
 spec:
     selector:
         app: pelias-api
     ports:
         - protocol: TCP
           port: 3100
-    type:{{ if .Values.externalAPIService }} LoadBalancer {{ else }} ClusterIP {{ end }}
+    type:{{ if .Values.api.externalService }} LoadBalancer {{ else }} ClusterIP {{ end }}

--- a/templates/configmap.tpl
+++ b/templates/configmap.tpl
@@ -91,7 +91,7 @@ data:
         },
         "openstreetmap": {
           "download": [{
-              "sourceURL": "http://planet.us-east-1.mapzen.com/planet-latest.osm.pbf"
+              "sourceURL": "https://planet.openstreetmap.org/pbf/planet-latest.osm.pbf"
           }],
           "datapath": "/data/openstreetmap",
           "import": [{


### PR DESCRIPTION
Majority of the build jobs for data sources uses busybox image to create initial folder in /data/ volume. However busybox uses different user/group ID to create a folder than pelias baseimage hence downloading data by data source container is not possible (permission denied). Fix is to set owner of created folder to 1000:1000 which is used by pelias image. 
Not sure why whosonfirst build is different from other data sources in terms of presistance volume and init containers, so I've moved it to the same format. 

Also URL for openstreetmap in configmap seems to be not working any more so I've replaced that with official openstreetmap link.

Added few comments to REAME.md