### PR TITLE
Autodetect snapshot name

### DIFF
--- a/elasticsearch/packer/scripts/default.sh
+++ b/elasticsearch/packer/scripts/default.sh
@@ -5,7 +5,7 @@ export DEBIAN_FRONTEND=noninteractive
 sudo apt-get update
 sudo apt-get upgrade -y
 
-sudo apt-get install htop dstat -y
+sudo apt-get install htop dstat jq -y
 
 echo "elasticsearch soft nofile 128000
 elasticsearch hard nofile 128000

--- a/elasticsearch/terraform/templates/load_snapshot.sh.tpl
+++ b/elasticsearch/terraform/templates/load_snapshot.sh.tpl
@@ -13,11 +13,6 @@ alias_name="${snapshot_alias_name}"
 replica_count="${snapshot_replica_count}"
 
 # check all required variables are set
-if [[ "$snapshot_name" == "" ]]; then
-  echo "snapshot_name not set, no snapshot will be loaded"
-  exit 0
-fi
-
 if [[ "$s3_bucket" == "" ]]; then
   echo "s3_bucket not set, no snapshot will be loaded"
   exit 0
@@ -82,6 +77,13 @@ curl -s -XPOST --fail "$cluster_url/_snapshot/$es_repo_name" -d "{
 echo
 
 ## 3. import snapshot
+
+## autodetect snapshot name if not specified
+if [[ "$snapshot_name" == "" ]]; then
+	snapshot_name=$(curl -s -XGET --fail "$cluster_url/_snapshot/$es_repo_name/_all" | jq -r .snapshots[0].snapshot)
+	echo "autodetected snapshot name is $snapshot_name"
+fi
+
 curl -s -XPOST --fail "$cluster_url/_snapshot/$es_repo_name/$snapshot_name/_restore" -d "{
   \"indices\": \"pelias\",
     \"rename_pattern\": \"pelias\",

--- a/elasticsearch/terraform/variables.tf
+++ b/elasticsearch/terraform/variables.tf
@@ -127,7 +127,7 @@ variable "snapshot_base_path" {
 }
 
 variable "snapshot_name" {
-  description = "The name of the snapshot to load from S3. If blank, no snapshot will be loaded"
+  description = "The name of the snapshot to load from S3. If blank, the first snapshot in the repository will be used"
   default = ""
 }
 


### PR DESCRIPTION
This improvement to the snapshot load scripts allows the snapshot name to be autodetected, saving a lot of manual effort and potential error when creating new clusters.

Now, if the `snapshot_name` variable is omitted, the first snapshot from the snapshot repository will automatically be used. This works well with the best practice we've discovered to keep each snapshot in its own repository (since otherwise it is difficult to separate the snapshots within a single repository).

This change requires `jq` to be installed on the AMIs used for Elasticsearch instances. However we love `jq` and usually end up installing it for many manual or investigative tasks, so having it present all the time is a good idea anyway.

Relevant ES documentation: https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-snapshots.html