### PR TITLE
Allow configuring more deployment settings

### DIFF
--- a/templates/interpolation-deployment.tpl
+++ b/templates/interpolation-deployment.tpl
@@ -4,10 +4,11 @@ metadata:
   name: pelias-interpolation
 spec:
   replicas: {{ .Values.interpolation.replicas }}
+  minReadySeconds: {{ .Values.interpolation.minReadySeconds }}
   strategy:
     rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
+      maxSurge: {{ .Values.interpolation.maxSurge }}
+      maxUnavailable: {{ .Values.interpolation.maxUnavailable }}
   template:
     metadata:
       labels:

--- a/templates/libpostal-deployment.tpl
+++ b/templates/libpostal-deployment.tpl
@@ -4,10 +4,11 @@ metadata:
   name: pelias-libpostal
 spec:
   replicas: {{ .Values.libpostal.replicas }}
+  minReadySeconds: {{ .Values.libpostal.minReadySeconds }}
   strategy:
     rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
+      maxSurge: {{ .Values.libpostal.maxSurge }}
+      maxUnavailable: {{ .Values.libpostal.maxUnavailable }}
   template:
     metadata:
       labels:

--- a/templates/pip-deployment.tpl
+++ b/templates/pip-deployment.tpl
@@ -4,10 +4,10 @@ metadata:
   name: pelias-pip
 spec:
   replicas: {{ .Values.pip.replicas }}
-  minReadySeconds: 60
+  minReadySeconds: {{ .Values.pip.minReadySeconds }}
   strategy:
     rollingUpdate:
-      maxSurge: 1
+      maxSurge: {{ .Values.pip.maxSurge }}
       maxUnavailable: {{ .Values.pip.maxUnavailable }}
   template:
     metadata:
@@ -59,7 +59,7 @@ spec:
             httpGet:
               path: /12/12
               port: 3102
-            initialDelaySeconds: 120 #PIP service takes a long time to start up
+            initialDelaySeconds: {{ .Values.pip.initialDelaySeconds }}
       volumes:
         - name: config-volume
           configMap:

--- a/templates/placeholder-deployment.tpl
+++ b/templates/placeholder-deployment.tpl
@@ -4,11 +4,11 @@ metadata:
   name: pelias-placeholder
 spec:
   replicas: {{ .Values.placeholder.replicas }}
-  minReadySeconds: 30
+  minReadySeconds: {{ .Values.placeholder.minReadySeconds }}
   strategy:
     rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
+      maxSurge: {{ .Values.placeholder.maxSurge }}
+      maxUnavailable: {{ .Values.placeholder.maxUnavailable }}
   template:
     metadata:
       labels:

--- a/values.yaml
+++ b/values.yaml
@@ -31,6 +31,9 @@ placeholder:
   replicas: 1
   host: "http://pelias-placeholder-service:3000/"
   dockerTag: "latest"
+  maxSurge: 1
+  maxUnavailable: 0
+  minReadySeconds: 5
   storeURL: "https://s3.amazonaws.com/pelias-data.nextzen.org/placeholder/store.sqlite3.gz"
   cpus: 1 # how many CPUs to allow using via the npm `cluster2` module
   retries: 1 # number of time the API will retry requests to placeholder
@@ -51,6 +54,9 @@ interpolation:
   replicas: 1
   host: "http://pelias-interpolation-service:3000/"
   dockerTag: "latest"
+  maxSurge: 1
+  maxUnavailable: 0
+  minReadySeconds: 5
   # URL prefix of location where streets.db and address.db will be downloaded
   downloadPath: " https://s3.amazonaws.com/pelias-data.nextzen.org/interpolation/current"
   retries: 1 # number of time the API will retry requests to interpolation service
@@ -69,9 +75,12 @@ pip:
   replicas: 1
   host: "http://pelias-pip-service:3102/"
   dockerTag: "latest"
+  maxSurge: 1
+  minReadySeconds: 5
   maxUnavailable: 0 # adjusts rolling update settings
   retries: 1 # number of time the API will retry requests to the pip service
   timeout: 5000 # time in ms the API will wait for pip service responses
+  initialDelaySeconds: 300 # pip service takes a long time to start up
   annotations: {}
   pvc: {}
 #    create: true


### PR DESCRIPTION
This ensures that `maxSurge`, `maxUnavailable`, and `minReadySeconds` deployment settings are configurable across all deployments.

Connects https://github.com/pelias/kubernetes/issues/50