### PR TITLE
Update links to hosted data and announce changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ This configuration is meant to be run on Kubernetes using real hardware or full 
 machines in the cloud. It could work on a personal computer with
 [minikube](https://github.com/kubernetes/minikube), but larger installations will likely benefit from additional RAM.
 
+**Announcement:** This project previously took advantage of full planet data
+for the [Placeholder](https://github.com/pelias/placeholder) and [Interpolation](https://github.com/pelias/interpolation/) services hosted by
+[Nextzen](https://www.nextzen.org/). Unfortunately this hosting is no longer available. By default, this project will now download data for the [Portland Metro](https://github.com/pelias/docker/tree/master/projects/portland-metro) area.
+
 ## Setup
 
 First, set up a Kubernetes cluster however works best for you. A popular choice is to use

--- a/values.yaml
+++ b/values.yaml
@@ -34,7 +34,7 @@ placeholder:
   maxSurge: 1
   maxUnavailable: 0
   minReadySeconds: 5
-  storeURL: "https://s3.amazonaws.com/pelias-data.nextzen.org/placeholder/store.sqlite3.gz"
+  storeURL: "https://s3.amazonaws.com/pelias-data.nextzen.org/portland-metro/placeholder/store.sqlite3.gz"
   cpus: 1 # how many CPUs to allow using via the npm `cluster2` module
   retries: 1 # number of time the API will retry requests to placeholder
   timeout: 5000 # time in ms the API will wait for placeholder responses
@@ -58,7 +58,7 @@ interpolation:
   maxUnavailable: 0
   minReadySeconds: 5
   # URL prefix of location where streets.db and address.db will be downloaded
-  downloadPath: " https://s3.amazonaws.com/pelias-data.nextzen.org/interpolation/current"
+  downloadPath: " https://s3.amazonaws.com/pelias-data.nextzen.org/portland-metro/interpolation"
   retries: 1 # number of time the API will retry requests to interpolation service
   timeout: 5000 # time in ms the API will wait for interpolation service responses
   annotations: {}


### PR DESCRIPTION
Unfortunately the hosting for some planet data that was used by default in the helm chart is not going to be available in the future.