### PR TITLE
94 Support node selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,7 @@ their default values. See values.yaml for all available options.
 | `elasticsearch.host`                   | Elasticsearch hostname                      | `elasticsearch-service`                                              |
 | `elasticsearch.port`                   | Elasticsearch access port                   | `9200`                                              |
 | `elasticsearch.protocol`               | Elasticsearch access protocol               | `http`                                              |
-| `elasticsearch.auth`                   | Elasticsearch authentication `user:pass`    | `-`                                                 |
-| `nodeSelector`                         | Configurable K8s nodeSelector for all pods  | `-`                                                 |
+| `elasticsearch.auth`                   | Elasticsearch authentication `user:pass`    | `-`                                              |
 | `pip.enabled`                          | Whether to enable pip service               | `true`                                              |
 | `pip.host`                             | Pip service url                             | `http://pelias-pip-service:3102/`                   |
 | `pip.pvc.create`                       | To use a custom PVC                         | `-`                                                 |

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ their default values. See values.yaml for all available options.
 | `elasticsearch.port`                   | Elasticsearch access port                   | `9200`                                              |
 | `elasticsearch.protocol`               | Elasticsearch access protocol               | `http`                                              |
 | `elasticsearch.auth`                   | Elasticsearch authentication `user:pass`    | `-`                                                 |
-| `nodeSelector`                         | Configurable K8s nodeSelector for pods      | `-`                                                 |
+| `nodeSelector`                         | Configurable K8s nodeSelector for all pods  | `-`                                                 |
 | `pip.enabled`                          | Whether to enable pip service               | `true`                                              |
 | `pip.host`                             | Pip service url                             | `http://pelias-pip-service:3102/`                   |
 | `pip.pvc.create`                       | To use a custom PVC                         | `-`                                                 |

--- a/README.md
+++ b/README.md
@@ -120,7 +120,8 @@ their default values. See values.yaml for all available options.
 | `elasticsearch.host`                   | Elasticsearch hostname                      | `elasticsearch-service`                                              |
 | `elasticsearch.port`                   | Elasticsearch access port                   | `9200`                                              |
 | `elasticsearch.protocol`               | Elasticsearch access protocol               | `http`                                              |
-| `elasticsearch.auth`                   | Elasticsearch authentication `user:pass`    | `-`                                              |
+| `elasticsearch.auth`                   | Elasticsearch authentication `user:pass`    | `-`                                                 |
+| `nodeSelector`                         | Configurable K8s nodeSelector for pods      | `-`                                                 |
 | `pip.enabled`                          | Whether to enable pip service               | `true`                                              |
 | `pip.host`                             | Pip service url                             | `http://pelias-pip-service:3102/`                   |
 | `pip.pvc.create`                       | To use a custom PVC                         | `-`                                                 |

--- a/templates/api-canary-deployment.tpl
+++ b/templates/api-canary-deployment.tpl
@@ -42,4 +42,8 @@ spec:
             items:
               - key: pelias.json
                 path: pelias.json
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+      {{- end }}
 {{- end -}}

--- a/templates/api-canary-deployment.tpl
+++ b/templates/api-canary-deployment.tpl
@@ -42,7 +42,7 @@ spec:
             items:
               - key: pelias.json
                 path: pelias.json
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.api.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
       {{- end }}

--- a/templates/api-canary-deployment.tpl
+++ b/templates/api-canary-deployment.tpl
@@ -42,8 +42,6 @@ spec:
             items:
               - key: pelias.json
                 path: pelias.json
-      {{- with .Values.api.nodeSelector }}
       nodeSelector:
-{{ toYaml . | indent 8 }}
-      {{- end }}
+{{ toYaml .Values.api.nodeSelector | indent 8 }}
 {{- end -}}

--- a/templates/api-deployment.tpl
+++ b/templates/api-deployment.tpl
@@ -44,7 +44,7 @@ spec:
             items:
               - key: pelias.json
                 path: pelias.json
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.api.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
       {{- end }}

--- a/templates/api-deployment.tpl
+++ b/templates/api-deployment.tpl
@@ -44,7 +44,5 @@ spec:
             items:
               - key: pelias.json
                 path: pelias.json
-      {{- with .Values.api.nodeSelector }}
       nodeSelector:
-{{ toYaml . | indent 8 }}
-      {{- end }}
+{{ toYaml .Values.api.nodeSelector | indent 8 }}

--- a/templates/api-deployment.tpl
+++ b/templates/api-deployment.tpl
@@ -44,3 +44,7 @@ spec:
             items:
               - key: pelias.json
                 path: pelias.json
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+      {{- end }}

--- a/templates/dashboard-deployment.yaml
+++ b/templates/dashboard-deployment.yaml
@@ -34,4 +34,8 @@ spec:
             requests:
               memory: 0.2Gi
               cpu: 0.01
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+      {{- end }}
 {{- end -}}

--- a/templates/dashboard-deployment.yaml
+++ b/templates/dashboard-deployment.yaml
@@ -34,8 +34,6 @@ spec:
             requests:
               memory: 0.2Gi
               cpu: 0.01
-      {{- with .Values.dashboard.nodeSelector }}
       nodeSelector:
-{{ toYaml . | indent 8 }}
-      {{- end }}
+{{ toYaml .Values.dashboard.nodeSelector | indent 8 }}
 {{- end -}}

--- a/templates/dashboard-deployment.yaml
+++ b/templates/dashboard-deployment.yaml
@@ -34,7 +34,7 @@ spec:
             requests:
               memory: 0.2Gi
               cpu: 0.01
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.dashboard.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
       {{- end }}

--- a/templates/interpolation-deployment.tpl
+++ b/templates/interpolation-deployment.tpl
@@ -56,7 +56,5 @@ spec:
         {{- else }}
           emptyDir: {}
         {{- end }}
-      {{- with .Values.interpolation.nodeSelector }}
       nodeSelector:
-{{ toYaml . | indent 8 }}
-      {{- end }}
+{{ toYaml .Values.interpolation.nodeSelector | indent 8 }}

--- a/templates/interpolation-deployment.tpl
+++ b/templates/interpolation-deployment.tpl
@@ -56,7 +56,7 @@ spec:
         {{- else }}
           emptyDir: {}
         {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.interpolation.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
       {{- end }}

--- a/templates/interpolation-deployment.tpl
+++ b/templates/interpolation-deployment.tpl
@@ -56,3 +56,7 @@ spec:
         {{- else }}
           emptyDir: {}
         {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+      {{- end }}

--- a/templates/libpostal-deployment.tpl
+++ b/templates/libpostal-deployment.tpl
@@ -36,7 +36,7 @@ spec:
             httpGet:
               path: /parse?address=readiness
               port: 4400
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.libpostal.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
       {{- end }}

--- a/templates/libpostal-deployment.tpl
+++ b/templates/libpostal-deployment.tpl
@@ -36,3 +36,7 @@ spec:
             httpGet:
               path: /parse?address=readiness
               port: 4400
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+      {{- end }}

--- a/templates/libpostal-deployment.tpl
+++ b/templates/libpostal-deployment.tpl
@@ -36,7 +36,5 @@ spec:
             httpGet:
               path: /parse?address=readiness
               port: 4400
-      {{- with .Values.libpostal.nodeSelector }}
       nodeSelector:
-{{ toYaml . | indent 8 }}
-      {{- end }}
+{{ toYaml .Values.libpostal.nodeSelector | indent 8 }}

--- a/templates/pip-deployment.tpl
+++ b/templates/pip-deployment.tpl
@@ -74,7 +74,7 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.pip.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
       {{- end }}

--- a/templates/pip-deployment.tpl
+++ b/templates/pip-deployment.tpl
@@ -74,3 +74,7 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+      {{- end }}

--- a/templates/pip-deployment.tpl
+++ b/templates/pip-deployment.tpl
@@ -74,7 +74,5 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
-      {{- with .Values.pip.nodeSelector }}
       nodeSelector:
-{{ toYaml . | indent 8 }}
-      {{- end }}
+{{ toYaml .Values.pip.nodeSelector | indent 8 }}

--- a/templates/placeholder-deployment.tpl
+++ b/templates/placeholder-deployment.tpl
@@ -60,7 +60,5 @@ spec:
         {{- else }}
           emptyDir: {}
 	{{- end }}
-      {{- with .Values.placeholder.nodeSelector }}
       nodeSelector:
-{{ toYaml . | indent 8 }}
-      {{- end }}
+{{ toYaml .Values.placeholder.nodeSelector | indent 8 }}

--- a/templates/placeholder-deployment.tpl
+++ b/templates/placeholder-deployment.tpl
@@ -54,9 +54,8 @@ spec:
               cpu: 0.1
       volumes:
         - name: data-volume
-        {{- if .Values.placeholder.pvc.create }}
-          persistentVolumeClaim:
-            claimName: {{ .Values.placeholder.pvc.name }}
-        {{- else }}
           emptyDir: {}
-        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+      {{- end }}

--- a/templates/placeholder-deployment.tpl
+++ b/templates/placeholder-deployment.tpl
@@ -54,8 +54,13 @@ spec:
               cpu: 0.1
       volumes:
         - name: data-volume
+        {{- if .Values.placeholder.pvc.create }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.placeholder.pvc.name }}
+        {{- else }}
           emptyDir: {}
-      {{- with .Values.nodeSelector }}
+	{{- end }}
+      {{- with .Values.placeholder.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
       {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -25,6 +25,7 @@ api:
     cpu: 0.1
   minReadySeconds: 10
   annotations: {}
+  nodeSelector: {}
 
 placeholder:
   enabled: true
@@ -39,6 +40,7 @@ placeholder:
   retries: 1 # number of time the API will retry requests to placeholder
   timeout: 5000 # time in ms the API will wait for placeholder responses
   annotations: {}
+  nodeSelector: {}
   pvc: {}
 #    create: true
 #    name: placeholder-pvc
@@ -55,6 +57,7 @@ libpostal:
   retries: 1 # number of time the API will retry requests to libpostal
   timeout: 5000 # time in ms the API will wait for libpostal responses
   annotations: {}
+  nodeSelector: {}
 
 interpolation:
   enabled: false
@@ -69,6 +72,7 @@ interpolation:
   retries: 1 # number of time the API will retry requests to interpolation service
   timeout: 5000 # time in ms the API will wait for interpolation service responses
   annotations: {}
+  nodeSelector: {}
   pvc: {}
 #    create: true
 #    name: interpolation-pvc
@@ -89,6 +93,7 @@ pip:
   timeout: 5000 # time in ms the API will wait for pip service responses
   initialDelaySeconds: 300 # pip service takes a long time to start up
   annotations: {}
+  nodeSelector: {}
   pvc: {}
 #    create: true
 #    name: pip-pvc
@@ -102,6 +107,7 @@ dashboard:
   replicas: 1
   dockerTag: "latest"
   domain: null # set this to enable an ingress
+  nodeSelector: {}
 
 # Deprecated fields
 # pipEnabled: true
@@ -114,5 +120,3 @@ dashboard:
 whosonfirst:
   sqlite: false
   dataHost: null
-
-nodeSelector: {}

--- a/values.yaml
+++ b/values.yaml
@@ -114,3 +114,5 @@ dashboard:
 whosonfirst:
   sqlite: false
   dataHost: null
+
+nodeSelector: {}


### PR DESCRIPTION
This PR allows a user to specify a nodeSelector object in the values.yaml file to configure what nodes all of the pods in this chart run on.