### PR TITLE
Support elasticsearch-health-logger

### DIFF
--- a/templates/health-logger-deployment.tpl
+++ b/templates/health-logger-deployment.tpl
@@ -1,0 +1,39 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: pelias-elasticsearch-healthlogger
+spec:
+  replicas: {{ .Values.healthlogger.replicas }}
+  minReadySeconds: {{ .Values.healthlogger.minReadySeconds  }}
+  strategy:
+    rollingUpdate:
+      maxSurge: {{ .Values.healthlogger.maxSurge }}
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: pelias-healthlogger
+      annotations:
+        image: pelias/elasticsearch-health-logger:{{ .Values.healthlogger.dockerTag }}
+        elasticsearch: {{ .Values.elasticsearch.host }}
+{{- if .Values.healthlogger.annotations }}
+{{ toYaml .Values.healthlogger.annotations | indent 8 }}
+{{- end }}
+    spec:
+      containers:
+        - name: pelias-healthlogger
+          image: pelias/elasticsearch-health-logger:{{ .Values.healthlogger.dockerTag }}
+          resources:
+            limits:
+              memory: 0.5Gi
+              cpu: 0.5
+            requests:
+              memory: {{ .Values.healthlogger.requests.memory | quote }}
+              cpu: {{ .Values.healthlogger.requests.cpu | quote }}
+          env:
+          - name: ELASTICSEARCH_HOST
+            value: "{{ .Values.elasticsearch.host }}:{{ .Values.elasticsearch.port}}"
+          - name: WATCH_INTERVAL
+            value: {{ .Values.healthlogger.watch_interval | quote }}
+      nodeSelector:
+{{ toYaml .Values.healthlogger.nodeSelector | indent 8 }}

--- a/values.yaml
+++ b/values.yaml
@@ -112,6 +112,19 @@ dashboard:
   domain: null # set this to enable an ingress
   nodeSelector: {}
 
+healthlogger:
+  replicas: 0
+  dockerTag: "latest"
+  maxSurge: 1
+  maxUnavailable: 0
+  minReadySeconds: 1
+  requests:
+    memory: 100Mi
+    cpu: 0.1
+  annotations: {}
+  nodeSelector: {}
+  watch_interval: 60
+
 # Deprecated fields
 # pipEnabled: true
 # pipHost: "http://pelias-pip-service:3102/"


### PR DESCRIPTION
This is a [small service](https://github.com/pelias/elasticsearch-health-logger) to poll the status of Elasticsearch and convert it to log entries, which can be used for monitoring.

