### PR TITLE
Remove configmap checksum annotation from interpolation deployment

### DIFF
--- a/templates/interpolation-deployment.tpl
+++ b/templates/interpolation-deployment.tpl
@@ -14,7 +14,6 @@ spec:
       labels:
         app: pelias-interpolation
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/configmap.tpl") . | sha256sum }}
 {{- if .Values.interpolation.annotations }}
 {{ toYaml .Values.interpolation.annotations | indent 8 }}
 {{- end }}


### PR DESCRIPTION
Deploying the interpolation service is too expensive for this
