### PR TITLE
Upgrade Helm charts for Kubernetes 1.16 compatibility.

### DIFF
--- a/templates/api-canary-deployment.tpl
+++ b/templates/api-canary-deployment.tpl
@@ -1,5 +1,5 @@
 {{- if .Values.api.canaryDockerTag }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pelias-api-canary

--- a/templates/api-deployment.tpl
+++ b/templates/api-deployment.tpl
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pelias-api

--- a/templates/dashboard-deployment.yaml
+++ b/templates/dashboard-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.dashboard.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pelias-dashboard

--- a/templates/health-logger-deployment.tpl
+++ b/templates/health-logger-deployment.tpl
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pelias-elasticsearch-healthlogger

--- a/templates/interpolation-deployment.tpl
+++ b/templates/interpolation-deployment.tpl
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pelias-interpolation

--- a/templates/libpostal-deployment.tpl
+++ b/templates/libpostal-deployment.tpl
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pelias-libpostal

--- a/templates/pip-deployment.tpl
+++ b/templates/pip-deployment.tpl
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pelias-pip

--- a/templates/placeholder-deployment.tpl
+++ b/templates/placeholder-deployment.tpl
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pelias-placeholder


### PR DESCRIPTION
:wave: I did some ~awesome~ minimal work for the Pelias project and would love for everyone to have a look at it and provide feedback.

---
#### Here's the reason for this change :rocket:
  - Initial hack at #111 

---
#### Here's what actually got changed :clap:
 - [x] Simple search and replace from `extensions/v1beta1` --> `apps/v1`, plus a **bonus** search and replace from `apps/v1beta1` --> `apps/v1`.
 - [x] Additionally, added `spec.selector.matchLabels.app` to deployment templates.

---
#### Here's how others can test the changes :eyes:
I tested very briefly via deployment to minikube: 
```bash
minikube start
helm install --name pelias --namespace pelias ./ -f ./values.yaml
```
This results in a success message.