### PR TITLE
Ephemeral storage limits

### DIFF
--- a/templates/interpolation-deployment.tpl
+++ b/templates/interpolation-deployment.tpl
@@ -32,9 +32,11 @@ spec:
             limits:
               memory: 3Gi
               cpu: 2
+              ephemeral-storage: {{ .Values.interpolation.limits.ephemeral_storage }}
             requests:
               memory: 512Mi
               cpu: 0.1
+              ephemeral-storage: {{ .Values.interpolation.requests.ephemeral_storage }}
       containers:
         - name: pelias-interpolation
           image: pelias/interpolation:{{ .Values.interpolation.dockerTag }}
@@ -50,9 +52,11 @@ spec:
             limits:
               memory: 3Gi
               cpu: 2
+              ephemeral-storage: {{ .Values.interpolation.limits.ephemeral_storage }}
             requests:
               memory: {{ .Values.interpolation.requests.memory | quote }}
               cpu: {{ .Values.interpolation.requests.cpu | quote }}
+              ephemeral-storage: {{ .Values.interpolation.requests.ephemeral_storage }}
       volumes:
         - name: data-volume
         {{- if .Values.interpolation.pvc.create }}

--- a/templates/placeholder-deployment.tpl
+++ b/templates/placeholder-deployment.tpl
@@ -31,9 +31,11 @@ spec:
             limits:
               memory: 1Gi
               cpu: 1.1
+              ephemeral-storage: {{ .Values.interpolation.limits.ephemeral_storage }}
             requests:
               memory: 100Mi
               cpu: 0.2
+              ephemeral-storage: {{ .Values.interpolation.requests.ephemeral_storage }}
       containers:
         - name: pelias-placeholder
           image: pelias/placeholder:{{ .Values.placeholder.dockerTag }}
@@ -49,9 +51,11 @@ spec:
             limits:
               memory: 1Gi
               cpu: 2
+              ephemeral-storage: {{ .Values.interpolation.limits.ephemeral_storage }}
             requests:
               memory: {{ .Values.placeholder.requests.memory | quote }}
               cpu: {{ .Values.placeholder.requests.cpu | quote }}
+              ephemeral-storage: {{ .Values.interpolation.requests.ephemeral_storage }}
       volumes:
         - name: data-volume
         {{- if .Values.placeholder.pvc.create }}

--- a/values.yaml
+++ b/values.yaml
@@ -74,9 +74,14 @@ interpolation:
   downloadPath: " https://s3.amazonaws.com/pelias-data.nextzen.org/portland-metro/interpolation"
   retries: 1 # number of time the API will retry requests to interpolation service
   timeout: 5000 # time in ms the API will wait for interpolation service responses
+  limits:
+    # cannot use a hyphen to match the k8s param due to https://github.com/helm/helm/issues/2192
+    ephemeral_storage: 5Gi
   requests:
     memory: 2Gi
     cpu: 0.1
+    # cannot use a hyphen to match the k8s param due to https://github.com/helm/helm/issues/2192
+    ephemeral_storage: 5Gi
   annotations: {}
   nodeSelector: {}
   pvc: {}

--- a/values.yaml
+++ b/values.yaml
@@ -39,9 +39,14 @@ placeholder:
   cpus: 1 # how many CPUs to allow using via the npm `cluster2` module
   retries: 1 # number of time the API will retry requests to placeholder
   timeout: 5000 # time in ms the API will wait for placeholder responses
+  limits:
+    # cannot use a hyphen to match the k8s param due to https://github.com/helm/helm/issues/2192
+    ephemeral_storage: 5Gi
   requests:
     memory: 512Mi
     cpu: 0.1
+    # cannot use a hyphen to match the k8s param due to https://github.com/helm/helm/issues/2192
+    ephemeral_storage: 5Gi
   annotations: {}
   nodeSelector: {}
   pvc: {}


### PR DESCRIPTION
This PR adds resource requests and limits for [ephemeral storage](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#local-ephemeral-storage) for the Placeholder and Interpolation services.

They both can use quite a bit of disk space, and without setting a reasonable value for the resource request, Kubernetes can get stuck in a loop where it repeatedly tries to launch a pod on a machine that doesn't have enough storage.

The defaults are currently set to 5GB for both services. The interpolation service will need a much bigger limit, at least 50GB, for full planet builds.