### PR TITLE
Use a separate configmap for canary deployments

### DIFF
--- a/templates/api-canary-deployment.tpl
+++ b/templates/api-canary-deployment.tpl
@@ -15,9 +15,9 @@ spec:
       labels:
         app: {{ if .Values.api.privateCanary }} pelias-api-private-canary {{ else }} pelias-api {{ end }}
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/configmap.tpl") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/canary-configmap.json.tpl") . | sha256sum }}
         image: pelias/api:{{ .Values.api.canaryDockerTag }}
-        elasticsearch: {{ .Values.elasticsearch.host }}
+        elasticsearch: {{ .Values.canary.elasticsearch.host | default .Values.elasticsearch.host }}
     spec:
       containers:
         - name: pelias-api
@@ -38,7 +38,7 @@ spec:
       volumes:
         - name: config-volume
           configMap:
-            name: pelias-json-configmap
+            name: pelias-json-canary-configmap
             items:
               - key: pelias.json
                 path: pelias.json

--- a/templates/canary-configmap.json.tpl
+++ b/templates/canary-configmap.json.tpl
@@ -1,0 +1,115 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pelias-json-canary-configmap
+data:
+  pelias.json: |
+    {
+      "esclient": {
+        "hosts": [{
+          "host": {{ .Values.canary.elasticsearch.host | default .Values.elasticsearch.host | quote }},
+          "port": {{ .Values.canary.elasticsearch.port | default .Values.elasticsearch.port }},
+          "protocol": {{ .Values.canary.elasticsearch.protocol | default .Values.elasticsearch.protocol | quote }}
+          {{- if or .Values.elasticsearch.auth .Values.canary.elasticsearch.auth }}
+          ,"auth": "{{ .Values.canary.elasticsearch.auth | default .Values.elasticsearch.auth }}"
+          {{- end }}
+        }]
+      },
+      "elasticsearch": {
+        "settings": {
+          "index": {
+            "number_of_replicas": "0",
+            "number_of_shards": "12",
+            "refresh_interval": "1m"
+          }
+        }
+      },
+      "api": {
+        "accessLog": "{{ .Values.api.accessLog }}",
+        "autocomplete": {
+          "exclude_address_length": {{ .Values.api.autocomplete.exclude_address_length }}
+        },
+        "attributionURL": "{{ .Values.api.attributionURL }}",
+        "indexName": "{{ .Values.api.indexName }}",
+        "services": {
+          {{ if .Values.placeholder.enabled  }}
+          "placeholder": {
+            "url": "{{ .Values.placeholder.host }}",
+            "retries": {{ .Values.placeholder.retries }},
+            "timeout": {{ .Values.placeholder.timeout }}
+          },
+          {{- end }}
+          {{- if .Values.interpolation.enabled }}
+          "interpolation": {
+            "url": "{{ .Values.interpolation.host }}",
+            "retries": {{ .Values.interpolation.retries }},
+            "timeout": {{ .Values.interpolation.timeout }}
+          },
+          {{- end }}
+          {{- if .Values.pip.enabled }}
+          "pip": {
+            "url": "{{ .Values.pip.host }}",
+            "retries": {{ .Values.pip.retries }},
+            "timeout": {{ .Values.pip.timeout }}
+          },
+          {{- end }}
+          "libpostal": {
+            "url": "{{ .Values.libpostal.host }}",
+            "retries": {{ .Values.libpostal.retries }},
+            "timeout": {{ .Values.libpostal.timeout }}
+          }
+        }
+      },
+      "acceptance-tests": {
+        "endpoints": {
+          "local": "http://pelias-api-service:3100/v1/"
+        }
+      },
+      "logger": {
+        "level": "info",
+        "json": true,
+        "timestamp": true
+      },
+      "imports": {
+        "adminLookup": {
+            "enabled": true,
+            "maxConcurrentReqs": 20
+        },
+        "services": {
+          "pip": {
+            "url": "http://pelias-pip-service:3102",
+            "timeout": 5000
+          }
+        },
+        "geonames": {
+          "datapath": "/data/geonames",
+          "countryCode": "ALL"
+        },
+        "openaddresses": {
+          "datapath": "/data/openaddresses",
+          "files": []
+        },
+        "openstreetmap": {
+          "download": [{
+              "sourceURL": "https://planet.openstreetmap.org/pbf/planet-latest.osm.pbf"
+          }],
+          "datapath": "/data/openstreetmap",
+          "import": [{
+            "filename": "planet-latest.osm.pbf"
+          }]
+        },
+        "polyline": {
+          "datapath": "/data/polylines",
+          "files": ["extract.0sv"]
+        },
+        "whosonfirst": {
+          "sqlite": {{ .Values.whosonfirst.sqlite }},
+          {{ if .Values.whosonfirst.dataHost }}
+          "dataHost": "{{ .Values.whosonfirst.dataHost}}",
+          {{ end }}
+          "importVenues": false,
+          "importPostalcodes": true,
+          "datapath": "/data/whosonfirst"
+        }
+      }
+    }


### PR DESCRIPTION
This allows for canary API deployments to have any setting in `pelias.json` configured differently from the baseline API deployment.

We will have to add support for more configuration values over time, but for now this allows for setting a different Elasticsearch host, which makes it easy to test two different Elasticsearch clusters at the same time.

For @geocodeearth, we plan to use this to test the roll out of Elasticsearch 6.