### PR TITLE
Use Pelias images instead of busybox

### DIFF
--- a/templates/interpolation-deployment.tpl
+++ b/templates/interpolation-deployment.tpl
@@ -20,7 +20,7 @@ spec:
     spec:
       initContainers:
         - name: download
-          image: busybox
+          image: pelias/interpolation:{{ .Values.interpolation.dockerTag }}
           command: [ "sh", "-c",
             "mkdir -p /data/interpolation/ &&\n
              wget -O - {{ .Values.interpolation.downloadPath }}/street.db.gz | gunzip > /data/interpolation/street.db &\n

--- a/templates/placeholder-deployment.tpl
+++ b/templates/placeholder-deployment.tpl
@@ -20,7 +20,7 @@ spec:
     spec:
       initContainers:
         - name: download
-          image: busybox
+          image: pelias/placeholder:{{ .Values.placeholder.dockerTag }}
           command: ["sh", "-c",
             "mkdir -p /data/placeholder/ &&\n
              wget -O- {{ .Values.placeholder.storeURL }} | gunzip > /data/placeholder/store.sqlite3" ]


### PR DESCRIPTION
These images have up to date, full, versions of both `wget` and `curl`.

In testing, it turns out that the busybox version of `wget` will max out a CPU when downloading at only around 50MB/sec, whereas the full version can handle almost 100MB/sec with minimal CPU usage.