### PR TITLE
Set up ephemeral storage resource limits for PIP

### DIFF
--- a/templates/pip-deployment.tpl
+++ b/templates/pip-deployment.tpl
@@ -34,9 +34,11 @@ spec:
             limits:
               memory: 3Gi
               cpu: 4
+              ephemeral-storage: {{ .Values.pip.limits.ephemeral_storage }}
             requests:
               memory: 1Gi
               cpu: 0.1
+              ephemeral-storage: {{ .Values.pip.requests.ephemeral_storage }}
       containers:
         - name: pelias-pip
           image: pelias/pip-service:{{ .Values.pip.dockerTag }}
@@ -52,9 +54,11 @@ spec:
             limits:
               memory: 10Gi
               cpu: 3
+              ephemeral-storage: {{ .Values.pip.limits.ephemeral_storage }}
             requests:
               memory: {{ .Values.pip.requests.memory | quote }}
               cpu: {{ .Values.pip.requests.cpu | quote }}
+              ephemeral-storage: {{ .Values.pip.requests.ephemeral_storage }}
           readinessProbe:
             httpGet:
               path: /12/12

--- a/values.yaml
+++ b/values.yaml
@@ -108,9 +108,14 @@ pip:
   retries: 1 # number of time the API will retry requests to the pip service
   timeout: 5000 # time in ms the API will wait for pip service responses
   initialDelaySeconds: 300 # pip service takes a long time to start up
+  limits:
+    # cannot use a hyphen to match the k8s param due to https://github.com/helm/helm/issues/2192
+    ephemeral_storage: 35Gi
   requests:
     memory: 5Gi
     cpu: 0.1
+    # cannot use a hyphen to match the k8s param due to https://github.com/helm/helm/issues/2192
+    ephemeral_storage: 35Gi
   annotations: {}
   nodeSelector: {}
   pvc: {}


### PR DESCRIPTION
The PIP service needs to download a lot of data so it definitely can benefit from ephemeral storage limits. This change adds the ability to configure them, as https://github.com/pelias/kubernetes/pull/113 did for Placeholder and interpolation.

The default is sufficient for a full planet download.