### PR TITLE
Allow configuring cpu/memory limits for PIP

### DIFF
--- a/templates/pip-deployment.tpl
+++ b/templates/pip-deployment.tpl
@@ -52,8 +52,8 @@ spec:
               value: "/etc/config/pelias.json"
           resources:
             limits:
-              memory: 10Gi
-              cpu: 3
+              memory: {{ .Values.pip.limits.memory }}
+              cpu: {{ .Values.pip.limits.cpu }}
               ephemeral-storage: {{ .Values.pip.limits.ephemeral_storage }}
             requests:
               memory: {{ .Values.pip.requests.memory | quote }}

--- a/values.yaml
+++ b/values.yaml
@@ -109,6 +109,8 @@ pip:
   timeout: 5000 # time in ms the API will wait for pip service responses
   initialDelaySeconds: 300 # pip service takes a long time to start up
   limits:
+    memory: 10Gi
+    cpu: 3
     # cannot use a hyphen to match the k8s param due to https://github.com/helm/helm/issues/2192
     ephemeral_storage: 35Gi
   requests:


### PR DESCRIPTION
This PR allows the CPU and memory resource limits to be configured for the PIP service.

The default values are now config driven but are unchanged.

Connects https://github.com/pelias/kubernetes/issues/50