### PR TITLE
Add empty value for default canary elasticsearch host

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -4,6 +4,10 @@ elasticsearch:
   port: 9200
   protocol: "http"
 
+canary:
+  elasticsearch:
+    host: null
+
 ## API settings
 api:
   replicas: 1


### PR DESCRIPTION
As of https://github.com/pelias/kubernetes/pull/115, an entry (even just `null`) was required for the canary.elasticsearch value in order to avoid an error.

The defaults should work out of the box, so this sets a default value for `canary.elasticsearch.host` to prevent the error.