### PR TITLE
Add missing default values for libpostal-service configuration

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -69,6 +69,9 @@ libpostal:
   replicas: 1
   host: "http://pelias-libpostal-service:4400/"
   dockerTag: "latest"
+  maxSurge: 1
+  maxUnavailable: 0
+  minReadySeconds: 5
   retries: 1 # number of time the API will retry requests to libpostal
   timeout: 5000 # time in ms the API will wait for libpostal responses
   annotations: {}


### PR DESCRIPTION
Looks like some default setting values were missed back in
https://github.com/pelias/kubernetes/pull/91

This was causing undesirable defaults for these values.