### PR TITLE
Add missing mandatory selector in Deployment:apps/v1 spec

### DIFF
--- a/templates/api-canary-deployment.tpl
+++ b/templates/api-canary-deployment.tpl
@@ -6,6 +6,9 @@ metadata:
 spec:
   replicas: {{ .Values.api.canaryReplicas }}
   minReadySeconds: {{ .Values.api.minReadySeconds }}
+  selector:
+    matchLabels:
+      app: pelias-api
   strategy:
     rollingUpdate:
       maxSurge: 1

--- a/templates/api-deployment.tpl
+++ b/templates/api-deployment.tpl
@@ -5,6 +5,9 @@ metadata:
 spec:
   replicas: {{ .Values.api.replicas }}
   minReadySeconds: {{ .Values.api.minReadySeconds  }}
+  selector:
+    matchLabels:
+      app: pelias-api
   strategy:
     rollingUpdate:
       maxSurge: 1

--- a/templates/dashboard-deployment.yaml
+++ b/templates/dashboard-deployment.yaml
@@ -6,6 +6,9 @@ metadata:
 spec:
   replicas: {{ .Values.dashboard.replicas }}
   minReadySeconds: 1
+  selector:
+    matchLabels:
+      app: pelias-dashboard
   strategy:
     rollingUpdate:
       maxSurge: 1

--- a/templates/health-logger-deployment.tpl
+++ b/templates/health-logger-deployment.tpl
@@ -5,6 +5,9 @@ metadata:
 spec:
   replicas: {{ .Values.healthlogger.replicas }}
   minReadySeconds: {{ .Values.healthlogger.minReadySeconds  }}
+  selector:
+    matchLabels:
+      app: pelias-healthlogger
   strategy:
     rollingUpdate:
       maxSurge: {{ .Values.healthlogger.maxSurge }}

--- a/templates/interpolation-deployment.tpl
+++ b/templates/interpolation-deployment.tpl
@@ -5,6 +5,9 @@ metadata:
 spec:
   replicas: {{ .Values.interpolation.replicas }}
   minReadySeconds: {{ .Values.interpolation.minReadySeconds }}
+  selector:
+    matchLabels:
+      app: pelias-interpolation
   strategy:
     rollingUpdate:
       maxSurge: {{ .Values.interpolation.maxSurge }}

--- a/templates/libpostal-deployment.tpl
+++ b/templates/libpostal-deployment.tpl
@@ -5,6 +5,9 @@ metadata:
 spec:
   replicas: {{ .Values.libpostal.replicas }}
   minReadySeconds: {{ .Values.libpostal.minReadySeconds }}
+  selector:
+    matchLabels:
+      app: pelias-libpostal
   strategy:
     rollingUpdate:
       maxSurge: {{ .Values.libpostal.maxSurge }}

--- a/templates/pip-deployment.tpl
+++ b/templates/pip-deployment.tpl
@@ -5,6 +5,9 @@ metadata:
 spec:
   replicas: {{ .Values.pip.replicas }}
   minReadySeconds: {{ .Values.pip.minReadySeconds }}
+  selector:
+    matchLabels:
+      app: pelias-pip
   strategy:
     rollingUpdate:
       maxSurge: {{ .Values.pip.maxSurge }}

--- a/templates/placeholder-deployment.tpl
+++ b/templates/placeholder-deployment.tpl
@@ -5,6 +5,9 @@ metadata:
 spec:
   replicas: {{ .Values.placeholder.replicas }}
   minReadySeconds: {{ .Values.placeholder.minReadySeconds }}
+  selector:
+    matchLabels:
+      app: pelias-placeholder
   strategy:
     rollingUpdate:
       maxSurge: {{ .Values.placeholder.maxSurge }}


### PR DESCRIPTION
:wave: I did some ~awesome~ work for the Pelias project and would love for everyone to have a look at it and provide feedback.

---
#### Here's the reason for this change :rocket:
<!-- good place to use the magic github words that connect issues with PRs, like 
  - Fixes pelias/pelias#0000
  - Closes pelias/pelias#0000
  - Connected to pelias/pelias#0000
you can also just use good ol' words to explain what this does -->
- Connected to pelias/kubernetes#112
---
#### Here's what actually got changed :clap:
<!-- try listing some of the things in a nifty checklist
- [x] :cat:
- [ ] :dog:
- [x] :rabbit:
-->
- [x] Added `spec.selector.matchLabels.app` to deployment templates.
---
#### Here's how others can test the changes :eyes:
<!-- this could be queries or just mentioning that you've written unit/end-to-end tests as part of this awesome work... -->
<!-- did we mention, test are amazing! :rainbow: -->
`helm install --name pelias --namespace pelias ./ -f ./values.yaml`
It results into a successful release
