### PR TITLE
Add `selector.matchLabels`

### DIFF
--- a/templates/api-canary-deployment.tpl
+++ b/templates/api-canary-deployment.tpl
@@ -6,6 +6,9 @@ metadata:
 spec:
   replicas: {{ .Values.api.canaryReplicas }}
   minReadySeconds: {{ .Values.api.minReadySeconds }}
+  selector:
+    matchLabels:
+      app: pelias-api
   strategy:
     rollingUpdate:
       maxSurge: 1

--- a/templates/api-canary-deployment.tpl
+++ b/templates/api-canary-deployment.tpl
@@ -8,7 +8,7 @@ spec:
   minReadySeconds: {{ .Values.api.minReadySeconds }}
   selector:
     matchLabels:
-      app: pelias-api
+      app: pelias-api-canary
   strategy:
     rollingUpdate:
       maxSurge: 1
@@ -16,7 +16,8 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ if .Values.api.privateCanary }} pelias-api-private-canary {{ else }} pelias-api {{ end }}
+        app: pelias-api-canary
+        app-group: {{ if .Values.api.privateCanary }} pelias-api-private-canary {{ else }} pelias-api {{ end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/canary-configmap.json.tpl") . | sha256sum }}
         image: pelias/api:{{ .Values.api.canaryDockerTag }}

--- a/templates/api-deployment.tpl
+++ b/templates/api-deployment.tpl
@@ -16,6 +16,7 @@ spec:
     metadata:
       labels:
         app: pelias-api
+        app-group: pelias-api
       annotations:
         image: pelias/api:{{ .Values.api.dockerTag }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.tpl") . | sha256sum }}

--- a/templates/api-deployment.tpl
+++ b/templates/api-deployment.tpl
@@ -5,6 +5,9 @@ metadata:
 spec:
   replicas: {{ .Values.api.replicas }}
   minReadySeconds: {{ .Values.api.minReadySeconds  }}
+  selector:
+    matchLabels:
+      app: pelias-api
   strategy:
     rollingUpdate:
       maxSurge: 1

--- a/templates/api-service.tpl
+++ b/templates/api-service.tpl
@@ -6,7 +6,7 @@ metadata:
       {{ if .Values.api.privateLoadBalancer }}service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0{{ end }}
 spec:
     selector:
-        app: pelias-api
+        app-group: pelias-api
     ports:
         - protocol: TCP
           port: 3100

--- a/templates/dashboard-deployment.yaml
+++ b/templates/dashboard-deployment.yaml
@@ -6,6 +6,9 @@ metadata:
 spec:
   replicas: {{ .Values.dashboard.replicas }}
   minReadySeconds: 1
+  selector:
+    matchLabels:
+      app: pelias-dashboard
   strategy:
     rollingUpdate:
       maxSurge: 1

--- a/templates/health-logger-deployment.tpl
+++ b/templates/health-logger-deployment.tpl
@@ -5,6 +5,9 @@ metadata:
 spec:
   replicas: {{ .Values.healthlogger.replicas }}
   minReadySeconds: {{ .Values.healthlogger.minReadySeconds  }}
+  selector:
+    matchLabels:
+      app: pelias-healthlogger
   strategy:
     rollingUpdate:
       maxSurge: {{ .Values.healthlogger.maxSurge }}

--- a/templates/interpolation-deployment.tpl
+++ b/templates/interpolation-deployment.tpl
@@ -5,6 +5,9 @@ metadata:
 spec:
   replicas: {{ .Values.interpolation.replicas }}
   minReadySeconds: {{ .Values.interpolation.minReadySeconds }}
+  selector:
+    matchLabels:
+      app: pelias-interpolation
   strategy:
     rollingUpdate:
       maxSurge: {{ .Values.interpolation.maxSurge }}

--- a/templates/libpostal-deployment.tpl
+++ b/templates/libpostal-deployment.tpl
@@ -5,6 +5,9 @@ metadata:
 spec:
   replicas: {{ .Values.libpostal.replicas }}
   minReadySeconds: {{ .Values.libpostal.minReadySeconds }}
+  selector:
+    matchLabels:
+      app: pelias-libpostal
   strategy:
     rollingUpdate:
       maxSurge: {{ .Values.libpostal.maxSurge }}

--- a/templates/pip-deployment.tpl
+++ b/templates/pip-deployment.tpl
@@ -5,6 +5,9 @@ metadata:
 spec:
   replicas: {{ .Values.pip.replicas }}
   minReadySeconds: {{ .Values.pip.minReadySeconds }}
+  selector:
+    matchLabels:
+      app: pelias-pip
   strategy:
     rollingUpdate:
       maxSurge: {{ .Values.pip.maxSurge }}

--- a/templates/placeholder-deployment.tpl
+++ b/templates/placeholder-deployment.tpl
@@ -5,6 +5,9 @@ metadata:
 spec:
   replicas: {{ .Values.placeholder.replicas }}
   minReadySeconds: {{ .Values.placeholder.minReadySeconds }}
+  selector:
+    matchLabels:
+      app: pelias-placeholder
   strategy:
     rollingUpdate:
       maxSurge: {{ .Values.placeholder.maxSurge }}


### PR DESCRIPTION
This is required in newer versions of Kubernetes.

Our API canary setup makes this _slightly_ trickier than normal, but it's not too bad.