### PR TITLE
feat: allow specifying `api.targets.auto_discover`

### DIFF
--- a/templates/canary-configmap.json.tpl
+++ b/templates/canary-configmap.json.tpl
@@ -31,6 +31,11 @@ data:
         },
         "attributionURL": "{{ .Values.api.attributionURL }}",
         "indexName": "{{ .Values.api.indexName }}",
+        {{ if (.Values.api.targets.auto_discover) and ( or (eq .Values.api.targets.auto_discover true) ( eq .Values.api.targets.auto_discover false ) ) }}
+        "targets": {
+          "auto_discover": {{ .Values.api.targets.auto_discover }}
+        },
+        {{- end }}
         "services": {
           {{ if .Values.placeholder.enabled  }}
           "placeholder": {

--- a/templates/configmap.tpl
+++ b/templates/configmap.tpl
@@ -31,6 +31,11 @@ data:
         },
         "attributionURL": "{{ .Values.api.attributionURL }}",
         "indexName": "{{ .Values.api.indexName }}",
+        {{ if (.Values.api.targets.auto_discover) and ( or (eq .Values.api.targets.auto_discover true) ( eq .Values.api.targets.auto_discover false ) ) }}
+        "targets": {
+          "auto_discover": {{ .Values.api.targets.auto_discover }}
+        },
+        {{- end }}
         "services": {
           {{ if .Values.placeholder.enabled  }}
           "placeholder": {

--- a/values.yaml
+++ b/values.yaml
@@ -24,6 +24,8 @@ api:
   accessLog: "common" # allows configuring access log format. Empty string disables access log
   autocomplete:
     exclude_address_length: 0
+  targets:
+    auto_discover: null # use default value
   requests:
     memory: 0.25Gi
     cpu: 0.1


### PR DESCRIPTION
This [API](https://github.com/pelias/api#configuration-via-pelias-config) configuration option is useful with custom data.

In the future, we may change the default (from false to true), so this PR does not set a default value of its own.