### PR TITLE
fix: remove importVenues flag

### DIFF
--- a/templates/canary-configmap.json.tpl
+++ b/templates/canary-configmap.json.tpl
@@ -112,7 +112,6 @@ data:
           {{ if .Values.whosonfirst.dataHost }}
           "dataHost": "{{ .Values.whosonfirst.dataHost}}",
           {{ end }}
-          "importVenues": false,
           "importPostalcodes": true,
           "datapath": "/data/whosonfirst"
         }

--- a/templates/configmap.tpl
+++ b/templates/configmap.tpl
@@ -113,7 +113,6 @@ data:
           {{ if .Values.whosonfirst.dataHost }}
           "dataHost": "{{ .Values.whosonfirst.dataHost}}",
           {{ end }}
-          "importVenues": false,
           "importPostalcodes": true,
           "datapath": "/data/whosonfirst"
         }


### PR DESCRIPTION
This flag was deprecated in https://github.com/pelias/whosonfirst/pull/503, and is no longer allowed in `pelias.json`